### PR TITLE
55 Fix file widget to show images when clicked

### DIFF
--- a/napari_allencell_annotator/controller/annotator_controller.py
+++ b/napari_allencell_annotator/controller/annotator_controller.py
@@ -125,14 +125,11 @@ class AnnotatorController:
         # TODO: DO WE WANT TO SAVE ALL IMAGES WITHOUT ANNOTATIONS
         # Save rest of annotations, even if empty
 
-        # self.record_annotations(self._annotation_model.get_curr_img_index())
-        #
-        # for idx in range(self._annotation_model.get_num_images()):
-        #     if self._annotation_model.get_image_at(idx) not in self._annotation_model.get_annotations().keys():
-        #         self._annotation_model.add_annotation(self._annotation_model.get_image_at(idx), [])
+        self.record_annotations(self._annotation_model.get_curr_img_index())
 
-        for idx in range(self._annotation_model.get_curr_img_index(), self._annotation_model.get_num_images()):
-            self._annotation_model.add_annotation(self._annotation_model.get_image_at(idx), [])
+        for idx in range(self._annotation_model.get_num_images()):
+            if self._annotation_model.get_image_at(idx) not in self._annotation_model.get_annotations().keys():
+                self._annotation_model.add_annotation(self._annotation_model.get_image_at(idx), [])
 
         self.write_csv()
         # reset optional fields in model to None (pre-annottion state)

--- a/napari_allencell_annotator/controller/annotator_controller.py
+++ b/napari_allencell_annotator/controller/annotator_controller.py
@@ -197,7 +197,9 @@ class AnnotatorController:
         record_idx : int
             The index of the image we should save annotations for
         """
-        if record_idx is not None and self._annotation_model.is_annotation_started():  # ignore recording annotations when loading first image or just starting out
+        if (
+            record_idx is not None and self._annotation_model.is_annotation_started()
+        ):  # ignore recording annotations when loading first image or just starting out
             # we're saving annotation for the image we just switched off of.
             self._annotation_model.add_annotation(
                 self._annotation_model.get_all_images()[record_idx], self.view.get_curr_annots()

--- a/napari_allencell_annotator/controller/annotator_controller.py
+++ b/napari_allencell_annotator/controller/annotator_controller.py
@@ -169,7 +169,7 @@ class AnnotatorController:
             # files_and_annots values are lists File Path ->[File Name, FMS, annot1val, annot2val ...]
             # if the file has not been annotated the list is just length 2 [File Name, FMS]
             if path is None or path not in list(self._annotation_model.get_annotations().keys()):
-                # if the image is un-annotated render the default values
+                # if the image is un-annotated render the default values or no image is selected
                 self.view.render_default_values()
             else:
                 # if the image has been annotated render the values that were entered

--- a/napari_allencell_annotator/controller/annotator_controller.py
+++ b/napari_allencell_annotator/controller/annotator_controller.py
@@ -168,7 +168,7 @@ class AnnotatorController:
             path: Path = self._annotation_model.get_curr_img()
             # files_and_annots values are lists File Path ->[File Name, FMS, annot1val, annot2val ...]
             # if the file has not been annotated the list is just length 2 [File Name, FMS]
-            if path is not None or path not in list(self._annotation_model.get_annotations().keys()):
+            if path is None or path not in list(self._annotation_model.get_annotations().keys()):
                 # if the image is un-annotated render the default values
                 self.view.render_default_values()
             else:

--- a/napari_allencell_annotator/controller/annotator_controller.py
+++ b/napari_allencell_annotator/controller/annotator_controller.py
@@ -130,6 +130,7 @@ class AnnotatorController:
 
         self.write_csv()
         # reset optional fields in model to None (pre-annottion state)
+        self._annotation_model.set_annotation_started(False)
         self._annotation_model.set_csv_save_path(None)
         self.view.set_mode(AnnotatorViewMode.VIEW)
 

--- a/napari_allencell_annotator/controller/annotator_controller.py
+++ b/napari_allencell_annotator/controller/annotator_controller.py
@@ -124,6 +124,13 @@ class AnnotatorController:
         """Reset values from annotating and change mode to ADD."""
         # TODO: DO WE WANT TO SAVE ALL IMAGES WITHOUT ANNOTATIONS
         # Save rest of annotations, even if empty
+
+        # self.record_annotations(self._annotation_model.get_curr_img_index())
+        #
+        # for idx in range(self._annotation_model.get_num_images()):
+        #     if self._annotation_model.get_image_at(idx) not in self._annotation_model.get_annotations().keys():
+        #         self._annotation_model.add_annotation(self._annotation_model.get_image_at(idx), [])
+
         for idx in range(self._annotation_model.get_curr_img_index(), self._annotation_model.get_num_images()):
             self._annotation_model.add_annotation(self._annotation_model.get_image_at(idx), [])
 

--- a/napari_allencell_annotator/controller/annotator_controller.py
+++ b/napari_allencell_annotator/controller/annotator_controller.py
@@ -122,6 +122,7 @@ class AnnotatorController:
 
     def stop_annotating(self):
         """Reset values from annotating and change mode to ADD."""
+        # TODO: DO WE WANT TO SAVE ALL IMAGES WITHOUT ANNOTATIONS
         self.record_annotations(self._annotation_model.get_curr_img_index())
 
         for idx in range(self._annotation_model.get_num_images()):

--- a/napari_allencell_annotator/controller/annotator_controller.py
+++ b/napari_allencell_annotator/controller/annotator_controller.py
@@ -164,7 +164,7 @@ class AnnotatorController:
         curr_img : Dict[str, str]
             The current image {'File Path' : 'path', 'Row' : str(rownum)}
         """
-        if self._annotation_model.get_annotations() is not None:
+        if self._annotation_model.is_annotation_started():
             path: Path = self._annotation_model.get_curr_img()
             # files_and_annots values are lists File Path ->[File Name, FMS, annot1val, annot2val ...]
             # if the file has not been annotated the list is just length 2 [File Name, FMS]

--- a/napari_allencell_annotator/controller/annotator_controller.py
+++ b/napari_allencell_annotator/controller/annotator_controller.py
@@ -161,31 +161,29 @@ class AnnotatorController:
         curr_img : Dict[str, str]
             The current image {'File Path' : 'path', 'Row' : str(rownum)}
         """
-        if self._annotation_model.get_annotations() is None:
-            return
-
-        path: Path = self._annotation_model.get_curr_img()
-        # files_and_annots values are lists File Path ->[File Name, FMS, annot1val, annot2val ...]
-        # if the file has not been annotated the list is just length 2 [File Name, FMS]
-        if path not in list(self._annotation_model.get_annotations().keys()):
-            # if the image is un-annotated render the default values
-            self.view.render_default_values()
-        else:
-            # if the image has been annotated render the values that were entered
-            # dictionary list [2::] is [annot1val, annot2val, ...]
-            self.view.render_values(self._annotation_model.get_annotations()[path])
-        # convert row to int
-        self.view.display_current_progress()
-        # if at the end disable next
-        if self._annotation_model.get_curr_img_index() == self._annotation_model.get_num_images() - 1:
-            self.view.next_btn.setEnabled(False)
-        else:
-            self.view.next_btn.setEnabled(True)
-        # if at the start disable prev
-        if self._annotation_model.get_curr_img_index() == 0:
-            self.view.prev_btn.setEnabled(False)
-        else:
-            self.view.prev_btn.setEnabled(True)
+        if self._annotation_model.get_annotations() is not None:
+            path: Path = self._annotation_model.get_curr_img()
+            # files_and_annots values are lists File Path ->[File Name, FMS, annot1val, annot2val ...]
+            # if the file has not been annotated the list is just length 2 [File Name, FMS]
+            if path not in list(self._annotation_model.get_annotations().keys()):
+                # if the image is un-annotated render the default values
+                self.view.render_default_values()
+            else:
+                # if the image has been annotated render the values that were entered
+                # dictionary list [2::] is [annot1val, annot2val, ...]
+                self.view.render_values(self._annotation_model.get_annotations()[path])
+            # convert row to int
+            self.view.display_current_progress()
+            # if at the end disable next
+            if self._annotation_model.get_curr_img_index() == self._annotation_model.get_num_images() - 1:
+                self.view.next_btn.setEnabled(False)
+            else:
+                self.view.next_btn.setEnabled(True)
+            # if at the start disable prev
+            if self._annotation_model.get_curr_img_index() == 0:
+                self.view.prev_btn.setEnabled(False)
+            else:
+                self.view.prev_btn.setEnabled(True)
 
     def record_annotations(self, record_idx: int):
         """

--- a/napari_allencell_annotator/controller/annotator_controller.py
+++ b/napari_allencell_annotator/controller/annotator_controller.py
@@ -125,6 +125,7 @@ class AnnotatorController:
         # TODO: DO WE WANT TO SAVE ALL IMAGES WITHOUT ANNOTATIONS
         self.record_annotations(self._annotation_model.get_curr_img_index())
 
+        # Save rest of annotations, even if empty
         for idx in range(self._annotation_model.get_num_images()):
             if self._annotation_model.get_image_at(idx) not in self._annotation_model.get_annotations():
                 self._annotation_model.add_annotation(self._annotation_model.get_image_at(idx), [])

--- a/napari_allencell_annotator/controller/annotator_controller.py
+++ b/napari_allencell_annotator/controller/annotator_controller.py
@@ -122,10 +122,6 @@ class AnnotatorController:
 
     def stop_annotating(self):
         """Reset values from annotating and change mode to ADD."""
-        # TODO: DO WE WANT TO SAVE ALL IMAGES WITHOUT ANNOTATIONS
-        self.record_annotations(self._annotation_model.get_curr_img_index())
-
-        # Save rest of annotations, even if empty
         self.record_annotations(self._annotation_model.get_curr_img_index())
 
         for idx in range(self._annotation_model.get_num_images()):

--- a/napari_allencell_annotator/controller/annotator_controller.py
+++ b/napari_allencell_annotator/controller/annotator_controller.py
@@ -130,7 +130,6 @@ class AnnotatorController:
 
         self.write_csv()
         # reset optional fields in model to None (pre-annottion state)
-        self._annotation_model.set_curr_img_index(None)
         self._annotation_model.set_csv_save_path(None)
         self.view.set_mode(AnnotatorViewMode.VIEW)
 

--- a/napari_allencell_annotator/controller/annotator_controller.py
+++ b/napari_allencell_annotator/controller/annotator_controller.py
@@ -161,6 +161,9 @@ class AnnotatorController:
         curr_img : Dict[str, str]
             The current image {'File Path' : 'path', 'Row' : str(rownum)}
         """
+        if self._annotation_model.get_annotations() is None:
+            return
+
         path: Path = self._annotation_model.get_curr_img()
         # files_and_annots values are lists File Path ->[File Name, FMS, annot1val, annot2val ...]
         # if the file has not been annotated the list is just length 2 [File Name, FMS]

--- a/napari_allencell_annotator/controller/annotator_controller.py
+++ b/napari_allencell_annotator/controller/annotator_controller.py
@@ -125,7 +125,7 @@ class AnnotatorController:
         self.record_annotations(self._annotation_model.get_curr_img_index())
 
         for idx in range(self._annotation_model.get_num_images()):
-            if self._annotation_model.get_image_at(idx) not in self._annotation_model.get_annotations().keys():
+            if self._annotation_model.get_image_at(idx) not in self._annotation_model.get_annotations():
                 self._annotation_model.add_annotation(self._annotation_model.get_image_at(idx), [])
 
         self.write_csv()

--- a/napari_allencell_annotator/controller/annotator_controller.py
+++ b/napari_allencell_annotator/controller/annotator_controller.py
@@ -168,13 +168,14 @@ class AnnotatorController:
             path: Path = self._annotation_model.get_curr_img()
             # files_and_annots values are lists File Path ->[File Name, FMS, annot1val, annot2val ...]
             # if the file has not been annotated the list is just length 2 [File Name, FMS]
-            if path not in list(self._annotation_model.get_annotations().keys()):
+            if path is not None or path not in list(self._annotation_model.get_annotations().keys()):
                 # if the image is un-annotated render the default values
                 self.view.render_default_values()
             else:
                 # if the image has been annotated render the values that were entered
                 # dictionary list [2::] is [annot1val, annot2val, ...]
                 self.view.render_values(self._annotation_model.get_annotations()[path])
+
             # convert row to int
             self.view.display_current_progress()
             # if at the end disable next
@@ -198,7 +199,7 @@ class AnnotatorController:
             The index of the image we should save annotations for
         """
         if (
-            record_idx is not None and self._annotation_model.is_annotation_started()
+            record_idx != -1 and self._annotation_model.is_annotation_started()
         ):  # ignore recording annotations when loading first image or just starting out
             # we're saving annotation for the image we just switched off of.
             self._annotation_model.add_annotation(

--- a/napari_allencell_annotator/controller/annotator_controller.py
+++ b/napari_allencell_annotator/controller/annotator_controller.py
@@ -164,7 +164,7 @@ class AnnotatorController:
         curr_img : Dict[str, str]
             The current image {'File Path' : 'path', 'Row' : str(rownum)}
         """
-        if self._annotation_model.is_annotation_started():
+        if self._annotation_model.get_annotations() is not None:
             path: Path = self._annotation_model.get_curr_img()
             # files_and_annots values are lists File Path ->[File Name, FMS, annot1val, annot2val ...]
             # if the file has not been annotated the list is just length 2 [File Name, FMS]

--- a/napari_allencell_annotator/controller/annotator_controller.py
+++ b/napari_allencell_annotator/controller/annotator_controller.py
@@ -196,7 +196,7 @@ class AnnotatorController:
         record_idx : int
             The index of the image we should save annotations for
         """
-        if record_idx is not None:  # ignore recording annotations when loading first image.
+        if record_idx is not None and self._annotation_model.is_annotation_started():  # ignore recording annotations when loading first image or just starting out
             # we're saving annotation for the image we just switched off of.
             self._annotation_model.add_annotation(
                 self._annotation_model.get_all_images()[record_idx], self.view.get_curr_annots()

--- a/napari_allencell_annotator/model/annotation_model.py
+++ b/napari_allencell_annotator/model/annotation_model.py
@@ -119,7 +119,7 @@ class AnnotatorModel(QObject):
         self._curr_img_index = idx
 
         # when we set the current index to None to exit training, we dont want to emit image_changed
-        if self._curr_img_index is not None and self._curr_img_index != self._previous_img_index:
+        if self._curr_img_index is not None:
             self.image_changed.emit()
 
     def get_curr_img(self) -> Path:

--- a/napari_allencell_annotator/model/annotation_model.py
+++ b/napari_allencell_annotator/model/annotation_model.py
@@ -173,5 +173,3 @@ class AnnotatorModel(QObject):
 
     def set_annotation_started(self, started: bool) -> None:
         self._annotation_started = started
-
-

--- a/napari_allencell_annotator/model/annotation_model.py
+++ b/napari_allencell_annotator/model/annotation_model.py
@@ -20,6 +20,7 @@ class AnnotatorModel(QObject):
     image_set_added: Signal = Signal()
     next_image: Signal = Signal()
     prev_image: Signal = Signal()
+    set_image: Signal = Signal(int)
 
     def __init__(self):
         super().__init__()
@@ -158,4 +159,7 @@ class AnnotatorModel(QObject):
 
     def prev_img(self) -> None:
         self.prev_image.emit()
+
+    def set_img(self, idx: int) -> None:
+        self.set_image.emit(idx)
 

--- a/napari_allencell_annotator/model/annotation_model.py
+++ b/napari_allencell_annotator/model/annotation_model.py
@@ -46,6 +46,8 @@ class AnnotatorModel(QObject):
         # None if annotating has not started.
         self._csv_save_path: Optional[Path] = None
 
+        self._annotation_started = False
+
     def get_annotation_keys(self) -> dict[str, Key]:
         return self._annotation_keys
 
@@ -162,4 +164,10 @@ class AnnotatorModel(QObject):
 
     def set_img(self, idx: int) -> None:
         self.set_image.emit(idx)
+
+    def is_annotation_started(self) -> bool:
+        return self._annotation_started
+
+    def set_annotation_started(self, started: bool) -> None:
+        self._annotation_started = started
 

--- a/napari_allencell_annotator/model/annotation_model.py
+++ b/napari_allencell_annotator/model/annotation_model.py
@@ -119,7 +119,7 @@ class AnnotatorModel(QObject):
         self._curr_img_index = idx
 
         # when we set the current index to None to exit training, we dont want to emit image_changed
-        if self._curr_img_index is not None:
+        if self._curr_img_index is not None and self._curr_img_index != self._previous_img_index:
             self.image_changed.emit()
 
     def get_curr_img(self) -> Path:
@@ -132,7 +132,8 @@ class AnnotatorModel(QObject):
         return self._created_annotations
 
     def add_annotation(self, file_path: Path, annotation: list[Any]):
-        self._created_annotations[file_path] = annotation
+        if self._created_annotations is not None:
+            self._created_annotations[file_path] = annotation
 
     def set_annotations(self, annotations: dict[Path, list[Any]]) -> None:
         self._created_annotations = annotations

--- a/napari_allencell_annotator/model/annotation_model.py
+++ b/napari_allencell_annotator/model/annotation_model.py
@@ -135,7 +135,7 @@ class AnnotatorModel(QObject):
         return self._created_annotations
 
     def add_annotation(self, file_path: Path, annotation: list[Any]):
-        self._created_annotations[file_path]: list[Any] = annotation
+        self._created_annotations[file_path] = annotation
 
     def set_annotations(self, annotations: dict[Path, list[Any]]) -> None:
         self._created_annotations = annotations

--- a/napari_allencell_annotator/model/annotation_model.py
+++ b/napari_allencell_annotator/model/annotation_model.py
@@ -138,8 +138,7 @@ class AnnotatorModel(QObject):
         return self._created_annotations
 
     def add_annotation(self, file_path: Path, annotation: list[Any]):
-        if self._created_annotations is not None:
-            self._created_annotations[file_path]: list[Any] = annotation
+        self._created_annotations[file_path]: list[Any] = annotation
 
     def set_annotations(self, annotations: dict[Path, list[Any]]) -> None:
         self._created_annotations = annotations

--- a/napari_allencell_annotator/model/annotation_model.py
+++ b/napari_allencell_annotator/model/annotation_model.py
@@ -133,7 +133,7 @@ class AnnotatorModel(QObject):
 
     def add_annotation(self, file_path: Path, annotation: list[Any]):
         if self._created_annotations is not None:
-            self._created_annotations[file_path] = annotation
+            self._created_annotations[file_path]: list[Any] = annotation
 
     def set_annotations(self, annotations: dict[Path, list[Any]]) -> None:
         self._created_annotations = annotations

--- a/napari_allencell_annotator/model/annotation_model.py
+++ b/napari_allencell_annotator/model/annotation_model.py
@@ -18,6 +18,8 @@ class AnnotatorModel(QObject):
     image_count_changed: Signal = Signal(int)
     images_shuffled: Signal = Signal(bool)
     image_set_added: Signal = Signal()
+    next_image: Signal = Signal()
+    prev_image: Signal = Signal()
 
     def __init__(self):
         super().__init__()
@@ -150,3 +152,10 @@ class AnnotatorModel(QObject):
 
     def get_csv_save_path(self) -> Path:
         return self._csv_save_path
+
+    def next_img(self) -> None:
+        self.next_image.emit()
+
+    def prev_img(self) -> None:
+        self.prev_image.emit()
+

--- a/napari_allencell_annotator/model/annotation_model.py
+++ b/napari_allencell_annotator/model/annotation_model.py
@@ -36,9 +36,9 @@ class AnnotatorModel(QObject):
         # THE FOLLOWING FIELDS ONLY ARE NEEDED WHEN ANNOTATING STARTS AND ARE INITIALIZED AFTER STARTING.
         # Current image index, which is none by default
         # Changes to curr_img_index through set_curr_img_index() emits an image_changed event which parts of the app
-        # react to display that image. None if the user has not started annotating.
+        # react to display that image. -1 if the user has not started annotating.
         self._curr_img_index: int = -1
-        self._previous_img_index: Optional[int] = -1  # index of previously viewed image, None by default
+        self._previous_img_index: int = -1  # index of previously viewed image, -1 by default
         # annotations that have been crated. If annotating has not started, is None by default.
         # dict of annotated image path -> list of annotations for that image
         self._created_annotations: Optional[dict[Path, list[Any]]] = None
@@ -123,8 +123,6 @@ class AnnotatorModel(QObject):
 
     def set_curr_img_index(self, idx: int) -> None:
         self._curr_img_index = idx
-
-        # when we set the current index to -1 to exit training, we dont want to emit image_changed
         self.image_changed.emit()
 
     def get_curr_img(self) -> Optional[Path]:

--- a/napari_allencell_annotator/model/annotation_model.py
+++ b/napari_allencell_annotator/model/annotation_model.py
@@ -157,4 +157,3 @@ class AnnotatorModel(QObject):
 
     def set_annotation_started(self, started: bool) -> None:
         self._annotation_started = started
-

--- a/napari_allencell_annotator/model/annotation_model.py
+++ b/napari_allencell_annotator/model/annotation_model.py
@@ -21,6 +21,7 @@ class AnnotatorModel(QObject):
     next_image: Signal = Signal()
     prev_image: Signal = Signal()
     set_image: Signal = Signal(int)
+    unselect_image: Signal = Signal()
 
     def __init__(self):
         super().__init__()
@@ -128,6 +129,9 @@ class AnnotatorModel(QObject):
         if self._curr_img_index is not None:
             self.image_changed.emit()
 
+        else:
+            self.unselect_image.emit()
+
     def get_curr_img(self) -> Path:
         if self.is_images_shuffled():
             return self._shuffled_images[self._curr_img_index]
@@ -169,4 +173,5 @@ class AnnotatorModel(QObject):
 
     def set_annotation_started(self, started: bool) -> None:
         self._annotation_started = started
+
 

--- a/napari_allencell_annotator/model/annotation_model.py
+++ b/napari_allencell_annotator/model/annotation_model.py
@@ -18,9 +18,6 @@ class AnnotatorModel(QObject):
     image_count_changed: Signal = Signal(int)
     images_shuffled: Signal = Signal(bool)
     image_set_added: Signal = Signal()
-    next_image: Signal = Signal()
-    prev_image: Signal = Signal()
-    set_image: Signal = Signal(int)
 
     def __init__(self):
         super().__init__()
@@ -154,15 +151,6 @@ class AnnotatorModel(QObject):
 
     def get_csv_save_path(self) -> Path:
         return self._csv_save_path
-
-    def next_img(self) -> None:
-        self.next_image.emit()
-
-    def prev_img(self) -> None:
-        self.prev_image.emit()
-
-    def set_img(self, idx: int) -> None:
-        self.set_image.emit(idx)
 
     def is_annotation_started(self) -> bool:
         return self._annotation_started

--- a/napari_allencell_annotator/util/file_utils.py
+++ b/napari_allencell_annotator/util/file_utils.py
@@ -42,9 +42,9 @@ class FileUtils:
         return extension in SUPPORTED_FILE_TYPES
 
     @staticmethod
-    def get_files_in_dir(dir_path: Path) -> list[Path]:
+    def get_sorted_files_in_dir(dir_path: Path) -> list[Path]:
         """
-        Return a list of paths to files in a directory.
+        Return a sorted list of paths to files in a directory.
 
         Parameters
         ----------

--- a/napari_allencell_annotator/util/file_utils.py
+++ b/napari_allencell_annotator/util/file_utils.py
@@ -51,7 +51,7 @@ class FileUtils:
         dir_path: list[Path]
             The path to a directory
         """
-        return list(dir_path.glob("*.*"))
+        return sorted(list(dir_path.glob("*.*")))
 
     @staticmethod
     def shuffle_file_list(files: list[Path]) -> list[Path]:

--- a/napari_allencell_annotator/view/annotator_view.py
+++ b/napari_allencell_annotator/view/annotator_view.py
@@ -85,6 +85,7 @@ class AnnotatorView(QFrame):
     ):
         super().__init__()
         self._annotator_model = model
+        self._annotator_model.unselect_image.connect(self.render_default_values)
         self._mode = mode
         label = QLabel("Annotations")
         label.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)

--- a/napari_allencell_annotator/view/annotator_view.py
+++ b/napari_allencell_annotator/view/annotator_view.py
@@ -85,7 +85,6 @@ class AnnotatorView(QFrame):
     ):
         super().__init__()
         self._annotator_model = model
-        self._annotator_model.unselect_image.connect(self.render_default_values)
         self._mode = mode
         label = QLabel("Annotations")
         label.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)

--- a/napari_allencell_annotator/view/annotator_view.py
+++ b/napari_allencell_annotator/view/annotator_view.py
@@ -85,6 +85,7 @@ class AnnotatorView(QFrame):
     ):
         super().__init__()
         self._annotator_model = model
+        self._annotator_model.image_changed.connect(self._handle_image_changed)
         self._mode = mode
         label = QLabel("Annotations")
         label.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
@@ -188,6 +189,10 @@ class AnnotatorView(QFrame):
         """
         self._mode = mode
         self._display_mode()
+
+    def _handle_image_changed(self):
+        if self._annotator_model.get_curr_img_index() == -1:
+            self.render_default_values()
 
     def display_current_progress(self):
         """

--- a/napari_allencell_annotator/view/images_view.py
+++ b/napari_allencell_annotator/view/images_view.py
@@ -201,15 +201,12 @@ class ImagesView(QFrame):
             Previous file
         """
         self.viewer.clear_layers()
-        previous = self.file_widget.item(self._annotator_model.get_previous_image_index())
-        if previous is not None:
-            previous.unhighlight()
 
-        current = self.file_widget.item(self._annotator_model.get_curr_img_index())
+        current: Path = self._annotator_model.get_curr_img()
         if current is not None:
-            img: ImageUtils = ImageUtils(current.file_path)
+            img: ImageUtils = ImageUtils(current)
             self.viewer.add_image(img.get_image_data())
-            current.highlight()
+
 
     def update_num_files_label(self, num_files: int) -> None:
         """

--- a/napari_allencell_annotator/view/images_view.py
+++ b/napari_allencell_annotator/view/images_view.py
@@ -231,7 +231,7 @@ class ImagesView(QFrame):
         dir_list : List[Path]
             The input list with dir[0] holding directory name.
         """
-        all_files_in_dir: list[Path] = FileUtils.get_files_in_dir(dir_path)
+        all_files_in_dir: list[Path] = FileUtils.get_sorted_files_in_dir(dir_path)
 
         if len(all_files_in_dir) < 1:
             self.viewer.alert("Folder is empty")

--- a/napari_allencell_annotator/view/images_view.py
+++ b/napari_allencell_annotator/view/images_view.py
@@ -286,6 +286,8 @@ class ImagesView(QFrame):
             Toggle state of the shuffle button.
         """
         new_toggle_state: bool = not self._annotator_model.is_images_shuffled()
+        self._annotator_model.set_curr_img_index(None)
+        self._annotator_model.set_previous_image_index(None)
         # self._update_shuff_text(new_toggle_state)
         if new_toggle_state:
             # Switching to shuffle: on

--- a/napari_allencell_annotator/view/images_view.py
+++ b/napari_allencell_annotator/view/images_view.py
@@ -117,6 +117,7 @@ class ImagesView(QFrame):
         self._annotator_model.image_changed.connect(self._display_img)
         self._annotator_model.image_count_changed.connect(self._handle_image_count_changed)
         self._annotator_model.images_shuffled.connect(self._handle_shuffle_ui)
+        self._annotator_model.images_shuffled.connect(self.viewer.clear_layers)
 
     def _handle_shuffle_ui(self, checked: bool) -> None:
         """
@@ -285,7 +286,6 @@ class ImagesView(QFrame):
             Toggle state of the shuffle button.
         """
         new_toggle_state: bool = not self._annotator_model.is_images_shuffled()
-        self.viewer.clear_layers()
         # self._update_shuff_text(new_toggle_state)
         if new_toggle_state:
             # Switching to shuffle: on

--- a/napari_allencell_annotator/view/images_view.py
+++ b/napari_allencell_annotator/view/images_view.py
@@ -353,8 +353,6 @@ class ImagesView(QFrame):
         Clear all image data from the model and the file widget.
         """
         self._annotator_model.clear_all_images()  # clear model
-        self.viewer.clear_layers()
-        self.file_widget.setCurrentItem(None)
         # self._annotator_model.set_shuffled_images(None)  # clear shuffled images, if any
 
     def start_annotating(self) -> None:
@@ -380,7 +378,8 @@ class ImagesView(QFrame):
         if count > 0:
             self._enable_delete_button()
             self._enable_shuffle_button()
-        elif count < 0:
+        else:
+            self.viewer.clear_layers()
             self.reset_buttons()
 
     def stop_annotating(self):

--- a/napari_allencell_annotator/view/images_view.py
+++ b/napari_allencell_annotator/view/images_view.py
@@ -343,9 +343,9 @@ class ImagesView(QFrame):
         if item.file_path in self._annotator_model.get_all_images():
             if self.file_widget.currentItem() == item:
                 self.viewer.clear_layers()
-                self.file_widget.setCurrentItem(None)
-            self._annotator_model.remove_image(item.file_path)
+
             self.file_widget.remove_item(item)
+            self._annotator_model.remove_image(item.file_path)
             self.update_num_files_label(self._annotator_model.get_num_images())
 
     def clear_all(self) -> None:

--- a/napari_allencell_annotator/view/images_view.py
+++ b/napari_allencell_annotator/view/images_view.py
@@ -354,6 +354,8 @@ class ImagesView(QFrame):
         Clear all image data from the model and the file widget.
         """
         self._annotator_model.clear_all_images()  # clear model
+        self.viewer.clear_layers()
+        self.file_widget.setCurrentItem(None)
         # self._annotator_model.set_shuffled_images(None)  # clear shuffled images, if any
 
     def start_annotating(self) -> None:

--- a/napari_allencell_annotator/view/images_view.py
+++ b/napari_allencell_annotator/view/images_view.py
@@ -342,6 +342,9 @@ class ImagesView(QFrame):
         # TODO when we delete from the model, connect file widget so that it deletes that entry itself without
         # us explicitly calling remove_item on it
         if item.file_path in self._annotator_model.get_all_images():
+            if self.file_widget.currentItem() == item:
+                self.viewer.clear_layers()
+                self.file_widget.setCurrentItem(None)
             self._annotator_model.remove_image(item.file_path)
             self.file_widget.remove_item(item)
             self.update_num_files_label(self._annotator_model.get_num_images())

--- a/napari_allencell_annotator/view/images_view.py
+++ b/napari_allencell_annotator/view/images_view.py
@@ -117,7 +117,6 @@ class ImagesView(QFrame):
         self._annotator_model.image_changed.connect(self._display_img)
         self._annotator_model.image_count_changed.connect(self._handle_image_count_changed)
         self._annotator_model.images_shuffled.connect(self._handle_shuffle_ui)
-        self._annotator_model.unselect_image.connect(self.viewer.clear_layers)
 
     def _handle_shuffle_ui(self, checked: bool) -> None:
         """
@@ -201,9 +200,9 @@ class ImagesView(QFrame):
             Previous file
         """
         self.viewer.clear_layers()
-        previous = self._annotator_model.get_previous_image_index()
+        previous = self.file_widget.item(self._annotator_model.get_previous_image_index())
         if previous is not None:
-            self.file_widget.item(previous).unhighlight()
+            previous.unhighlight()
 
         current = self.file_widget.item(self._annotator_model.get_curr_img_index())
         if current is not None:

--- a/napari_allencell_annotator/view/images_view.py
+++ b/napari_allencell_annotator/view/images_view.py
@@ -286,8 +286,7 @@ class ImagesView(QFrame):
             Toggle state of the shuffle button.
         """
         new_toggle_state: bool = not self._annotator_model.is_images_shuffled()
-        self._annotator_model.set_curr_img_index(None)
-        self._annotator_model.set_previous_image_index(None)
+        self.viewer.clear_layers()
         # self._update_shuff_text(new_toggle_state)
         if new_toggle_state:
             # Switching to shuffle: on

--- a/napari_allencell_annotator/view/images_view.py
+++ b/napari_allencell_annotator/view/images_view.py
@@ -117,6 +117,7 @@ class ImagesView(QFrame):
         self._annotator_model.image_changed.connect(self._display_img)
         self._annotator_model.image_count_changed.connect(self._handle_image_count_changed)
         self._annotator_model.images_shuffled.connect(self._handle_shuffle_ui)
+        self._annotator_model.unselect_image.connect(self.viewer.clear_layers)
 
     def _handle_shuffle_ui(self, checked: bool) -> None:
         """
@@ -285,7 +286,7 @@ class ImagesView(QFrame):
             Toggle state of the shuffle button.
         """
         new_toggle_state: bool = not self._annotator_model.is_images_shuffled()
-        self.viewer.clear_layers()
+        self.file_widget.setCurrentItem(None)
         # self._update_shuff_text(new_toggle_state)
         if new_toggle_state:
             # Switching to shuffle: on
@@ -342,7 +343,6 @@ class ImagesView(QFrame):
         # us explicitly calling remove_item on it
         if item.file_path in self._annotator_model.get_all_images():
             if self.file_widget.currentItem() == item:
-                self.viewer.clear_layers()
                 self.file_widget.setCurrentItem(None)
             self._annotator_model.remove_image(item.file_path)
             self.file_widget.remove_item(item)
@@ -353,7 +353,6 @@ class ImagesView(QFrame):
         Clear all image data from the model and the file widget.
         """
         self._annotator_model.clear_all_images()  # clear model
-        self.viewer.clear_layers()
         self.file_widget.setCurrentItem(None)
         # self._annotator_model.set_shuffled_images(None)  # clear shuffled images, if any
 

--- a/napari_allencell_annotator/view/main_view.py
+++ b/napari_allencell_annotator/view/main_view.py
@@ -317,8 +317,6 @@ class MainView(QFrame):
         self._annotator_model.set_img(starting_idx)
         self._annotator_model.set_annotation_started(True)
 
-
-
     def annotating_shortcuts_on(self):
         """Create annotation keyboard shortcuts and connect them to slots."""
 

--- a/napari_allencell_annotator/view/main_view.py
+++ b/napari_allencell_annotator/view/main_view.py
@@ -314,8 +314,8 @@ class MainView(QFrame):
             self._images_view.hide_image_paths()
 
         # set first image
-        self._annotator_model.set_previous_image_index(None)
-        self._annotator_model.set_curr_img_index(starting_idx)
+        self._annotator_model.set_img(starting_idx)
+
 
 
     def annotating_shortcuts_on(self):

--- a/napari_allencell_annotator/view/main_view.py
+++ b/napari_allencell_annotator/view/main_view.py
@@ -315,6 +315,7 @@ class MainView(QFrame):
 
         # set first image
         self._annotator_model.set_img(starting_idx)
+        self._annotator_model.set_annotation_started(True)
 
 
 

--- a/napari_allencell_annotator/view/main_view.py
+++ b/napari_allencell_annotator/view/main_view.py
@@ -500,9 +500,8 @@ class MainView(QFrame):
         image is being annotated, enable previous button.
         """
 
-        self._annotator_model.set_previous_image_index(self._annotator_model.get_curr_img_index())
+        self._annotator_model.next_img()
         # This dispatches a signal which updates  annotations dictionary and sets the next image
-        self._annotator_model.set_curr_img_index(self._annotator_model.get_curr_img_index() + 1)
         self.annots.view.save_btn.setEnabled(True)
 
     def _prev_image_clicked(self):
@@ -511,8 +510,7 @@ class MainView(QFrame):
 
         If the first image is being annotated, disable button.
         """
-        self._annotator_model.set_previous_image_index(self._annotator_model.get_curr_img_index())
-        self._annotator_model.set_curr_img_index(self._annotator_model.get_curr_img_index() - 1)
+        self._annotator_model.prev_img()
         self.annots.view.save_btn.setEnabled(True)
 
     def _image_selected(self):

--- a/napari_allencell_annotator/view/main_view.py
+++ b/napari_allencell_annotator/view/main_view.py
@@ -155,8 +155,13 @@ class MainView(QFrame):
                         self._annotator_model.add_annotation(path, row[2:])
                     # self._images_view.add_new_item(path)
                 # start at row 0 if annotation data was not used from csv
+
                 file.close()
             self._annotator_model.set_all_images(image_list)
+            if shuffled:
+                self._annotator_model.set_shuffled_images(
+                    FileUtils.shuffle_file_list(self._annotator_model.get_all_images())
+                )
             self.annots.start_viewing(use_annots)
 
     def _shuffle_toggled(self, checked: bool):

--- a/napari_allencell_annotator/view/main_view.py
+++ b/napari_allencell_annotator/view/main_view.py
@@ -279,7 +279,7 @@ class MainView(QFrame):
                 if annot_path in old_images_list:
                     # if the annotation is complete move to front
                     if annot_list and len(annot_list) == len(self._annotator_model.get_annotation_keys()):
-                        new_images_list.insert(0, annot_path)
+                        new_images_list.insert(starting_idx, annot_path)
                         old_images_list.remove(annot_path)
                         starting_idx = starting_idx + 1
                     else:

--- a/napari_allencell_annotator/view/main_view.py
+++ b/napari_allencell_annotator/view/main_view.py
@@ -155,11 +155,14 @@ class MainView(QFrame):
                     # self._images_view.add_new_item(path)
                 # start at row 0 if annotation data was not used from csv
                 file.close()
-            self._annotator_model.set_all_images(image_list)
-            if shuffled:
-                self._annotator_model.set_shuffled_images(
-                    FileUtils.shuffle_file_list(self._annotator_model.get_all_images())
-                )
+                self._annotator_model.set_all_images(image_list)
+                if shuffled:
+                    self._annotator_model.set_shuffled_images(
+                        FileUtils.shuffle_file_list(self._annotator_model.get_all_images())
+                    )
+                else:
+                    self._annotator_model.set_shuffled_images(None)
+
             self.annots.start_viewing(use_annots)
 
     def _shuffle_toggled(self, checked: bool):

--- a/napari_allencell_annotator/view/main_view.py
+++ b/napari_allencell_annotator/view/main_view.py
@@ -155,7 +155,6 @@ class MainView(QFrame):
                         self._annotator_model.add_annotation(path, row[2:])
                     # self._images_view.add_new_item(path)
                 # start at row 0 if annotation data was not used from csv
-
                 file.close()
             self._annotator_model.set_all_images(image_list)
             if shuffled:

--- a/napari_allencell_annotator/view/main_view.py
+++ b/napari_allencell_annotator/view/main_view.py
@@ -133,8 +133,7 @@ class MainView(QFrame):
                 )
                 file = open(file_path)
                 reader = csv.reader(file)
-                shuffled: str = next(reader)[1]
-                # shuffled = self.str_to_bool(shuffled)
+                shuffled: bool = self.str_to_bool(next(reader)[1])
                 # annotation data header
                 annts = next(reader)[1]
                 # set annotation Key dict in model with json header info

--- a/napari_allencell_annotator/view/main_view.py
+++ b/napari_allencell_annotator/view/main_view.py
@@ -314,7 +314,8 @@ class MainView(QFrame):
             self._images_view.hide_image_paths()
 
         # set first image
-        self._annotator_model.set_img(starting_idx)
+        self._annotator_model.set_previous_image_index(self._annotator_model.get_curr_img_index())
+        self._annotator_model.set_curr_img_index(starting_idx)
         self._annotator_model.set_annotation_started(True)
 
 
@@ -501,7 +502,8 @@ class MainView(QFrame):
         image is being annotated, enable previous button.
         """
 
-        self._annotator_model.next_img()
+        self._annotator_model.set_previous_image_index(self._annotator_model.get_curr_img_index())
+        self._annotator_model.set_curr_img_index(self._annotator_model.get_curr_img_index() + 1)
         # This dispatches a signal which updates  annotations dictionary and sets the next image
         self.annots.view.save_btn.setEnabled(True)
 
@@ -511,7 +513,8 @@ class MainView(QFrame):
 
         If the first image is being annotated, disable button.
         """
-        self._annotator_model.prev_img()
+        self._annotator_model.set_previous_image_index(self._annotator_model.get_curr_img_index())
+        self._annotator_model.set_curr_img_index(self._annotator_model.get_curr_img_index() - 1)
         self.annots.view.save_btn.setEnabled(True)
 
     def _image_selected(self):

--- a/napari_allencell_annotator/view/main_view.py
+++ b/napari_allencell_annotator/view/main_view.py
@@ -503,8 +503,8 @@ class MainView(QFrame):
         """
 
         self._annotator_model.set_previous_image_index(self._annotator_model.get_curr_img_index())
-        self._annotator_model.set_curr_img_index(self._annotator_model.get_curr_img_index() + 1)
         # This dispatches a signal which updates  annotations dictionary and sets the next image
+        self._annotator_model.set_curr_img_index(self._annotator_model.get_curr_img_index() + 1)
         self.annots.view.save_btn.setEnabled(True)
 
     def _prev_image_clicked(self):

--- a/napari_allencell_annotator/view/main_view.py
+++ b/napari_allencell_annotator/view/main_view.py
@@ -318,8 +318,6 @@ class MainView(QFrame):
         self._annotator_model.set_curr_img_index(starting_idx)
         self._annotator_model.set_annotation_started(True)
 
-
-
     def annotating_shortcuts_on(self):
         """Create annotation keyboard shortcuts and connect them to slots."""
 

--- a/napari_allencell_annotator/widgets/files_widget.py
+++ b/napari_allencell_annotator/widgets/files_widget.py
@@ -73,15 +73,8 @@ class FilesWidget(QListWidget):
         prev_item:
             the previous file item
         """
-        if prev_item is None:
-            self._annotator_model.set_previous_image_index(None)
-        else:
-            self._annotator_model.set_previous_image_index(self.row(prev_item))
-
-        if curr_item is None:
-            self._annotator_model.set_curr_img_index(None)
-        else:
-            self._annotator_model.set_curr_img_index(self.row(curr_item))
+        self._annotator_model.set_previous_image_index(self.row(prev_item))
+        self._annotator_model.set_curr_img_index(self.row(curr_item))
 
     def unhide_all(self) -> None:
         """Display the file names on all files in the list."""

--- a/napari_allencell_annotator/widgets/files_widget.py
+++ b/napari_allencell_annotator/widgets/files_widget.py
@@ -47,9 +47,14 @@ class FilesWidget(QListWidget):
         self.setCurrentItem(None)
         self._annotator_model = annotator_model
 
-        self._annotator_model.image_changed.connect(
-            lambda: self.setCurrentItem(self.item(self._annotator_model.get_curr_img_index()))
+        self._annotator_model.next_image.connect(
+            lambda: self.setCurrentItem(self.item(self._annotator_model.get_curr_img_index() + 1))
         )
+
+        self._annotator_model.prev_image.connect(
+            lambda: self.setCurrentItem(self.item(self._annotator_model.get_curr_img_index() - 1))
+        )
+
         self._annotator_model.images_shuffled.connect(self._handle_shuffle)
         self._annotator_model.image_set_added.connect(
             lambda: self._handle_shuffle(self._annotator_model.is_images_shuffled())
@@ -70,13 +75,10 @@ class FilesWidget(QListWidget):
         """
         if prev_item is None:
             self._annotator_model.set_previous_image_index(None)
-        elif self.row(prev_item) != self._annotator_model.get_previous_image_index():
+        else:
             self._annotator_model.set_previous_image_index(self.row(prev_item))
 
-        if curr_item is None:
-            self._annotator_model.set_curr_img_index(None)
-        elif self.row(curr_item) != self._annotator_model.get_curr_img_index():
-            self._annotator_model.set_curr_img_index(self.row(curr_item))
+        self._annotator_model.set_curr_img_index(self.row(curr_item))
 
 
     def unhide_all(self) -> None:

--- a/napari_allencell_annotator/widgets/files_widget.py
+++ b/napari_allencell_annotator/widgets/files_widget.py
@@ -59,10 +59,7 @@ class FilesWidget(QListWidget):
 
     def _handle_image_changed(self):
         with QSignalBlocker(self):
-            if self._annotator_model.get_curr_img_index() is not None:
-                self.setCurrentItem(self.item(self._annotator_model.get_curr_img_index()))
-            else:
-                self.setCurrentItem(None)
+            self.setCurrentItem(self.item(self._annotator_model.get_curr_img_index()))
 
     def _handle_file_item_changed(self, curr_item: FileItem, prev_item: FileItem) -> None:
         """

--- a/napari_allencell_annotator/widgets/files_widget.py
+++ b/napari_allencell_annotator/widgets/files_widget.py
@@ -78,7 +78,10 @@ class FilesWidget(QListWidget):
         else:
             self._annotator_model.set_previous_image_index(self.row(prev_item))
 
-        self._annotator_model.set_curr_img_index(self.row(curr_item))
+        if curr_item is None:
+            self._annotator_model.set_curr_img_index(None)
+        else:
+            self._annotator_model.set_curr_img_index(self.row(curr_item))
 
 
     def unhide_all(self) -> None:

--- a/napari_allencell_annotator/widgets/files_widget.py
+++ b/napari_allencell_annotator/widgets/files_widget.py
@@ -57,10 +57,16 @@ class FilesWidget(QListWidget):
         self._annotator_model.image_count_changed.connect(self._handle_image_count_change)
         self.currentItemChanged.connect(self._handle_item_changed)
 
-    def _handle_item_changed(self, item: FileItem):
-        if item is not None:
-            self._annotator_model.set_previous_image_index(self._annotator_model.get_curr_img_index())
-            self._annotator_model.set_curr_img_index(self.row(item))
+    def _handle_item_changed(self, curr_item: FileItem, prev_item: FileItem):
+        if prev_item is not None:
+            self._annotator_model.set_previous_image_index(self.row(prev_item))
+        else:
+            self._annotator_model.set_previous_image_index(None)
+
+        if curr_item is not None :
+            self._annotator_model.set_curr_img_index(self.row(curr_item))
+        else:
+            self._annotator_model.set_curr_img_index(None)
 
     def unhide_all(self) -> None:
         """Display the file names on all files in the list."""

--- a/napari_allencell_annotator/widgets/files_widget.py
+++ b/napari_allencell_annotator/widgets/files_widget.py
@@ -55,6 +55,11 @@ class FilesWidget(QListWidget):
             lambda: self._handle_shuffle(self._annotator_model.is_images_shuffled())
         )
         self._annotator_model.image_count_changed.connect(self._handle_image_count_change)
+        self.currentItemChanged.connect(self._handle_item_changed)
+
+    def _handle_item_changed(self, item: FileItem):
+        self._annotator_model.set_previous_image_index(self._annotator_model.get_curr_img_index())
+        self._annotator_model.set_curr_img_index(self.row(item))
 
     def unhide_all(self) -> None:
         """Display the file names on all files in the list."""

--- a/napari_allencell_annotator/widgets/files_widget.py
+++ b/napari_allencell_annotator/widgets/files_widget.py
@@ -85,7 +85,6 @@ class FilesWidget(QListWidget):
         else:
             self._annotator_model.set_curr_img_index(self.row(curr_item))
 
-
     def unhide_all(self) -> None:
         """Display the file names on all files in the list."""
         for i in range(self.count()):

--- a/napari_allencell_annotator/widgets/files_widget.py
+++ b/napari_allencell_annotator/widgets/files_widget.py
@@ -83,7 +83,6 @@ class FilesWidget(QListWidget):
         else:
             self._annotator_model.set_curr_img_index(self.row(curr_item))
 
-
     def unhide_all(self) -> None:
         """Display the file names on all files in the list."""
         for i in range(self.count()):

--- a/napari_allencell_annotator/widgets/files_widget.py
+++ b/napari_allencell_annotator/widgets/files_widget.py
@@ -58,15 +58,17 @@ class FilesWidget(QListWidget):
         self.currentItemChanged.connect(self._handle_item_changed)
 
     def _handle_item_changed(self, curr_item: FileItem, prev_item: FileItem):
-        if prev_item is not None:
-            self._annotator_model.set_previous_image_index(self.row(prev_item))
-        else:
-            self._annotator_model.set_previous_image_index(None)
 
-        if curr_item is not None :
-            self._annotator_model.set_curr_img_index(self.row(curr_item))
-        else:
+        if prev_item is None:
+            self._annotator_model.set_previous_image_index(None)
+        elif self.row(prev_item) != self._annotator_model.get_previous_image_index():
+            self._annotator_model.set_previous_image_index(self.row(prev_item))
+
+        if curr_item is None:
             self._annotator_model.set_curr_img_index(None)
+        elif self.row(curr_item) != self._annotator_model.get_curr_img_index():
+            self._annotator_model.set_curr_img_index(self.row(curr_item))
+
 
     def unhide_all(self) -> None:
         """Display the file names on all files in the list."""

--- a/napari_allencell_annotator/widgets/files_widget.py
+++ b/napari_allencell_annotator/widgets/files_widget.py
@@ -57,8 +57,17 @@ class FilesWidget(QListWidget):
         self._annotator_model.image_count_changed.connect(self._handle_image_count_change)
         self.currentItemChanged.connect(self._handle_item_changed)
 
-    def _handle_item_changed(self, curr_item: FileItem, prev_item: FileItem):
+    def _handle_item_changed(self, curr_item: FileItem, prev_item: FileItem) -> None:
+        """
+        Update the model when the current item in the file widget is changed if it has not been updated.
 
+        Parameters
+        ----------
+        curr_item:
+            the current file item
+        prev_item:
+            the previous file item
+        """
         if prev_item is None:
             self._annotator_model.set_previous_image_index(None)
         elif self.row(prev_item) != self._annotator_model.get_previous_image_index():

--- a/napari_allencell_annotator/widgets/files_widget.py
+++ b/napari_allencell_annotator/widgets/files_widget.py
@@ -61,6 +61,14 @@ class FilesWidget(QListWidget):
         with QSignalBlocker(self):
             self.setCurrentItem(self.item(self._annotator_model.get_curr_img_index()))
 
+            previous = self.item(self._annotator_model.get_previous_image_index())
+            if previous is not None:
+                previous.unhighlight()
+
+            current = self.item(self._annotator_model.get_curr_img_index())
+            if current is not None:
+                current.highlight()
+
     def _handle_file_item_changed(self, curr_item: FileItem, prev_item: FileItem) -> None:
         """
         Update the model when the current item in the file widget is changed if it has not been updated.

--- a/napari_allencell_annotator/widgets/files_widget.py
+++ b/napari_allencell_annotator/widgets/files_widget.py
@@ -58,8 +58,9 @@ class FilesWidget(QListWidget):
         self.currentItemChanged.connect(self._handle_item_changed)
 
     def _handle_item_changed(self, item: FileItem):
-        self._annotator_model.set_previous_image_index(self._annotator_model.get_curr_img_index())
-        self._annotator_model.set_curr_img_index(self.row(item))
+        if item is not None:
+            self._annotator_model.set_previous_image_index(self._annotator_model.get_curr_img_index())
+            self._annotator_model.set_curr_img_index(self.row(item))
 
     def unhide_all(self) -> None:
         """Display the file names on all files in the list."""

--- a/napari_allencell_annotator/widgets/files_widget.py
+++ b/napari_allencell_annotator/widgets/files_widget.py
@@ -54,7 +54,7 @@ class FilesWidget(QListWidget):
         self._annotator_model.prev_image.connect(
             lambda: self.setCurrentItem(self.item(self._annotator_model.get_curr_img_index() - 1))
         )
-
+        self._annotator_model.set_image.connect(lambda idx: self.setCurrentItem(self.item(idx)))
         self._annotator_model.images_shuffled.connect(self._handle_shuffle)
         self._annotator_model.image_set_added.connect(
             lambda: self._handle_shuffle(self._annotator_model.is_images_shuffled())


### PR DESCRIPTION
<h2>Context</h2>
#55 In the main branch, the user able to click on the file items to display any image both before and after starting annotation. This feature did not work in the current version. The only way to browse between images is to click on the next and previous buttons. The file widget did not allow the user to click on file items to display images and see the annotations associated with them.

<h2>Changes</h2>

**files_widget.py:** 

- `_handle_image_changed`: This method is connected to the `image_changed` signal. It sets the current file item to the current image in the `annotator_model`. The currentItemChanged is blocked to prevent updating the model twice.

 - `_handle_item_changed`: This method is connected to the `currentItemChanged` event. When the current item in the file widget is set to a new item, it will emit this signal. The method then updates the current index and the previous index in the annotator model, which emits the `image_changed` signal to trigger other functions to record previous annotation and display the image.

**annotation_model.py**

- `self._annotation_started`: This attribute allows the plugin to know whether the annotation has been started. If not, it should not record anything to the annotation list. `is_annotation_started` and `set_annotation_started` are get and set methods for this attribute.

**annotation_controller.py**

- Change how unannotated images are written to a csv: When users stop annotating, instead of creating an empty list for each unannotated image starting from the current image index + 1, I changed it so that it checks every image from first to last to see if it has been annotated. If not, the image will be added to the annotation list with an empty annotation. This change fixes the problem where images did not get saved if they were skipped using the file widget.
- Set `self._annotation_started` to False when `stop_annotating()` is called to stop recording annotations.
- `set_curr_img()`: Add an if statement to make sure that the plugin only render annotations when the `_created_annotations` list is not empty.

**images_view.py**

- Made a few changes to ensure the viewer and the file widget are cleared with no current item selected when the user shuffles, delete the current image, and delete all images.

**main_view.py**

- `_setup_annotating`: Set the previous index to the current image index instead of None to ensure that the previous file item is unhighlighted after annotation starts.
- Set `self._annotation_started` to True to start recording annotations.