### PR TITLE
67 Annotator widget reacts to shuffle, delete, delete all

### DIFF
--- a/napari_allencell_annotator/controller/annotator_controller.py
+++ b/napari_allencell_annotator/controller/annotator_controller.py
@@ -197,7 +197,9 @@ class AnnotatorController:
         record_idx : int
             The index of the image we should save annotations for
         """
-        if record_idx is not None and self._annotation_model.is_annotation_started():  # ignore recording annotations when loading first image or just starting out
+        if (
+            record_idx is not None and self._annotation_model.is_annotation_started()
+        ):  # ignore recording annotations when loading first image or just starting out
             # we're saving annotation for the image we just switched off of.
             self._annotation_model.add_annotation(
                 self._annotation_model.get_all_images()[record_idx], self.view.get_curr_annots()

--- a/napari_allencell_annotator/controller/annotator_controller.py
+++ b/napari_allencell_annotator/controller/annotator_controller.py
@@ -169,7 +169,7 @@ class AnnotatorController:
             # files_and_annots values are lists File Path ->[File Name, FMS, annot1val, annot2val ...]
             # if the file has not been annotated the list is just length 2 [File Name, FMS]
             if path is None or path not in list(self._annotation_model.get_annotations().keys()):
-                # if the image is un-annotated render the default values
+                # if the image is un-annotated render the default values or no image is selected
                 self.view.render_default_values()
             else:
                 # if the image has been annotated render the values that were entered

--- a/napari_allencell_annotator/controller/annotator_controller.py
+++ b/napari_allencell_annotator/controller/annotator_controller.py
@@ -168,7 +168,7 @@ class AnnotatorController:
             path: Path = self._annotation_model.get_curr_img()
             # files_and_annots values are lists File Path ->[File Name, FMS, annot1val, annot2val ...]
             # if the file has not been annotated the list is just length 2 [File Name, FMS]
-            if path is not None or path not in list(self._annotation_model.get_annotations().keys()):
+            if path is None or path not in list(self._annotation_model.get_annotations().keys()):
                 # if the image is un-annotated render the default values
                 self.view.render_default_values()
             else:

--- a/napari_allencell_annotator/controller/annotator_controller.py
+++ b/napari_allencell_annotator/controller/annotator_controller.py
@@ -168,13 +168,14 @@ class AnnotatorController:
             path: Path = self._annotation_model.get_curr_img()
             # files_and_annots values are lists File Path ->[File Name, FMS, annot1val, annot2val ...]
             # if the file has not been annotated the list is just length 2 [File Name, FMS]
-            if path not in list(self._annotation_model.get_annotations().keys()):
+            if path is not None or path not in list(self._annotation_model.get_annotations().keys()):
                 # if the image is un-annotated render the default values
                 self.view.render_default_values()
             else:
                 # if the image has been annotated render the values that were entered
                 # dictionary list [2::] is [annot1val, annot2val, ...]
                 self.view.render_values(self._annotation_model.get_annotations()[path])
+
             # convert row to int
             self.view.display_current_progress()
             # if at the end disable next
@@ -198,7 +199,7 @@ class AnnotatorController:
             The index of the image we should save annotations for
         """
         if (
-            record_idx is not None and self._annotation_model.is_annotation_started()
+            record_idx != -1 and self._annotation_model.is_annotation_started()
         ):  # ignore recording annotations when loading first image or just starting out
             # we're saving annotation for the image we just switched off of.
             self._annotation_model.add_annotation(

--- a/napari_allencell_annotator/model/annotation_model.py
+++ b/napari_allencell_annotator/model/annotation_model.py
@@ -173,5 +173,3 @@ class AnnotatorModel(QObject):
 
     def set_annotation_started(self, started: bool) -> None:
         self._annotation_started = started
-
-

--- a/napari_allencell_annotator/model/annotation_model.py
+++ b/napari_allencell_annotator/model/annotation_model.py
@@ -36,9 +36,9 @@ class AnnotatorModel(QObject):
         # THE FOLLOWING FIELDS ONLY ARE NEEDED WHEN ANNOTATING STARTS AND ARE INITIALIZED AFTER STARTING.
         # Current image index, which is none by default
         # Changes to curr_img_index through set_curr_img_index() emits an image_changed event which parts of the app
-        # react to display that image. None if the user has not started annotating.
+        # react to display that image. -1 if the user has not started annotating.
         self._curr_img_index: int = -1
-        self._previous_img_index: Optional[int] = -1  # index of previously viewed image, None by default
+        self._previous_img_index: int = -1  # index of previously viewed image, -1 by default
         # annotations that have been crated. If annotating has not started, is None by default.
         # dict of annotated image path -> list of annotations for that image
         self._created_annotations: Optional[dict[Path, list[Any]]] = None
@@ -123,8 +123,6 @@ class AnnotatorModel(QObject):
 
     def set_curr_img_index(self, idx: int) -> None:
         self._curr_img_index = idx
-
-        # when we set the current index to -1 to exit training, we dont want to emit image_changed
         self.image_changed.emit()
 
     def get_curr_img(self) -> Optional[Path]:

--- a/napari_allencell_annotator/model/annotation_model.py
+++ b/napari_allencell_annotator/model/annotation_model.py
@@ -21,6 +21,7 @@ class AnnotatorModel(QObject):
     next_image: Signal = Signal()
     prev_image: Signal = Signal()
     set_image: Signal = Signal(int)
+    unselect_image: Signal = Signal()
 
     def __init__(self):
         super().__init__()
@@ -128,6 +129,9 @@ class AnnotatorModel(QObject):
         if self._curr_img_index is not None:
             self.image_changed.emit()
 
+        else:
+            self.unselect_image.emit()
+
     def get_curr_img(self) -> Path:
         if self.is_images_shuffled():
             return self._shuffled_images[self._curr_img_index]
@@ -169,4 +173,5 @@ class AnnotatorModel(QObject):
 
     def set_annotation_started(self, started: bool) -> None:
         self._annotation_started = started
+
 

--- a/napari_allencell_annotator/util/file_utils.py
+++ b/napari_allencell_annotator/util/file_utils.py
@@ -42,9 +42,9 @@ class FileUtils:
         return extension in SUPPORTED_FILE_TYPES
 
     @staticmethod
-    def get_files_in_dir(dir_path: Path) -> list[Path]:
+    def get_sorted_files_in_dir(dir_path: Path) -> list[Path]:
         """
-        Return a list of paths to files in a directory.
+        Return a sorted list of paths to files in a directory.
 
         Parameters
         ----------

--- a/napari_allencell_annotator/util/file_utils.py
+++ b/napari_allencell_annotator/util/file_utils.py
@@ -51,7 +51,7 @@ class FileUtils:
         dir_path: list[Path]
             The path to a directory
         """
-        return list(dir_path.glob("*.*"))
+        return sorted(list(dir_path.glob("*.*")))
 
     @staticmethod
     def shuffle_file_list(files: list[Path]) -> list[Path]:

--- a/napari_allencell_annotator/view/annotator_view.py
+++ b/napari_allencell_annotator/view/annotator_view.py
@@ -85,6 +85,7 @@ class AnnotatorView(QFrame):
     ):
         super().__init__()
         self._annotator_model = model
+        self._annotator_model.unselect_image.connect(self.render_default_values)
         self._mode = mode
         label = QLabel("Annotations")
         label.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)

--- a/napari_allencell_annotator/view/annotator_view.py
+++ b/napari_allencell_annotator/view/annotator_view.py
@@ -85,7 +85,6 @@ class AnnotatorView(QFrame):
     ):
         super().__init__()
         self._annotator_model = model
-        self._annotator_model.unselect_image.connect(self.render_default_values)
         self._mode = mode
         label = QLabel("Annotations")
         label.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)

--- a/napari_allencell_annotator/view/images_view.py
+++ b/napari_allencell_annotator/view/images_view.py
@@ -231,7 +231,7 @@ class ImagesView(QFrame):
         dir_list : List[Path]
             The input list with dir[0] holding directory name.
         """
-        all_files_in_dir: list[Path] = FileUtils.get_files_in_dir(dir_path)
+        all_files_in_dir: list[Path] = FileUtils.get_sorted_files_in_dir(dir_path)
 
         if len(all_files_in_dir) < 1:
             self.viewer.alert("Folder is empty")

--- a/napari_allencell_annotator/view/images_view.py
+++ b/napari_allencell_annotator/view/images_view.py
@@ -117,7 +117,6 @@ class ImagesView(QFrame):
         self._annotator_model.image_changed.connect(self._display_img)
         self._annotator_model.image_count_changed.connect(self._handle_image_count_changed)
         self._annotator_model.images_shuffled.connect(self._handle_shuffle_ui)
-        self._annotator_model.unselect_image.connect(self.viewer.clear_layers)
 
     def _handle_shuffle_ui(self, checked: bool) -> None:
         """
@@ -201,9 +200,9 @@ class ImagesView(QFrame):
             Previous file
         """
         self.viewer.clear_layers()
-        previous = self._annotator_model.get_previous_image_index()
+        previous = self.file_widget.item(self._annotator_model.get_previous_image_index())
         if previous is not None:
-            self.file_widget.item(previous).unhighlight()
+            previous.unhighlight()
 
         current = self.file_widget.item(self._annotator_model.get_curr_img_index())
         if current is not None:

--- a/napari_allencell_annotator/view/images_view.py
+++ b/napari_allencell_annotator/view/images_view.py
@@ -117,6 +117,7 @@ class ImagesView(QFrame):
         self._annotator_model.image_changed.connect(self._display_img)
         self._annotator_model.image_count_changed.connect(self._handle_image_count_changed)
         self._annotator_model.images_shuffled.connect(self._handle_shuffle_ui)
+        self._annotator_model.unselect_image.connect(self.viewer.clear_layers)
 
     def _handle_shuffle_ui(self, checked: bool) -> None:
         """
@@ -285,7 +286,7 @@ class ImagesView(QFrame):
             Toggle state of the shuffle button.
         """
         new_toggle_state: bool = not self._annotator_model.is_images_shuffled()
-        self.viewer.clear_layers()
+        self.file_widget.setCurrentItem(None)
         # self._update_shuff_text(new_toggle_state)
         if new_toggle_state:
             # Switching to shuffle: on
@@ -342,7 +343,6 @@ class ImagesView(QFrame):
         # us explicitly calling remove_item on it
         if item.file_path in self._annotator_model.get_all_images():
             if self.file_widget.currentItem() == item:
-                self.viewer.clear_layers()
                 self.file_widget.setCurrentItem(None)
             self._annotator_model.remove_image(item.file_path)
             self.file_widget.remove_item(item)
@@ -353,7 +353,6 @@ class ImagesView(QFrame):
         Clear all image data from the model and the file widget.
         """
         self._annotator_model.clear_all_images()  # clear model
-        self.viewer.clear_layers()
         self.file_widget.setCurrentItem(None)
         # self._annotator_model.set_shuffled_images(None)  # clear shuffled images, if any
 

--- a/napari_allencell_annotator/view/main_view.py
+++ b/napari_allencell_annotator/view/main_view.py
@@ -317,8 +317,6 @@ class MainView(QFrame):
         self._annotator_model.set_img(starting_idx)
         self._annotator_model.set_annotation_started(True)
 
-
-
     def annotating_shortcuts_on(self):
         """Create annotation keyboard shortcuts and connect them to slots."""
 

--- a/napari_allencell_annotator/view/main_view.py
+++ b/napari_allencell_annotator/view/main_view.py
@@ -155,8 +155,13 @@ class MainView(QFrame):
                         self._annotator_model.add_annotation(path, row[2:])
                     # self._images_view.add_new_item(path)
                 # start at row 0 if annotation data was not used from csv
+
                 file.close()
             self._annotator_model.set_all_images(image_list)
+            if shuffled:
+                self._annotator_model.set_shuffled_images(
+                    FileUtils.shuffle_file_list(self._annotator_model.get_all_images())
+                )
             self.annots.start_viewing(use_annots)
 
     def _shuffle_toggled(self, checked: bool):

--- a/napari_allencell_annotator/view/main_view.py
+++ b/napari_allencell_annotator/view/main_view.py
@@ -279,7 +279,7 @@ class MainView(QFrame):
                 if annot_path in old_images_list:
                     # if the annotation is complete move to front
                     if annot_list and len(annot_list) == len(self._annotator_model.get_annotation_keys()):
-                        new_images_list.insert(0, annot_path)
+                        new_images_list.insert(starting_idx, annot_path)
                         old_images_list.remove(annot_path)
                         starting_idx = starting_idx + 1
                     else:

--- a/napari_allencell_annotator/view/main_view.py
+++ b/napari_allencell_annotator/view/main_view.py
@@ -155,11 +155,14 @@ class MainView(QFrame):
                     # self._images_view.add_new_item(path)
                 # start at row 0 if annotation data was not used from csv
                 file.close()
-            self._annotator_model.set_all_images(image_list)
-            if shuffled:
-                self._annotator_model.set_shuffled_images(
-                    FileUtils.shuffle_file_list(self._annotator_model.get_all_images())
-                )
+                self._annotator_model.set_all_images(image_list)
+                if shuffled:
+                    self._annotator_model.set_shuffled_images(
+                        FileUtils.shuffle_file_list(self._annotator_model.get_all_images())
+                    )
+                else:
+                    self._annotator_model.set_shuffled_images(None)
+
             self.annots.start_viewing(use_annots)
 
     def _shuffle_toggled(self, checked: bool):

--- a/napari_allencell_annotator/view/main_view.py
+++ b/napari_allencell_annotator/view/main_view.py
@@ -155,7 +155,6 @@ class MainView(QFrame):
                         self._annotator_model.add_annotation(path, row[2:])
                     # self._images_view.add_new_item(path)
                 # start at row 0 if annotation data was not used from csv
-
                 file.close()
             self._annotator_model.set_all_images(image_list)
             if shuffled:

--- a/napari_allencell_annotator/view/main_view.py
+++ b/napari_allencell_annotator/view/main_view.py
@@ -133,8 +133,7 @@ class MainView(QFrame):
                 )
                 file = open(file_path)
                 reader = csv.reader(file)
-                shuffled: str = next(reader)[1]
-                # shuffled = self.str_to_bool(shuffled)
+                shuffled: bool = self.str_to_bool(next(reader)[1])
                 # annotation data header
                 annts = next(reader)[1]
                 # set annotation Key dict in model with json header info

--- a/napari_allencell_annotator/widgets/files_widget.py
+++ b/napari_allencell_annotator/widgets/files_widget.py
@@ -73,15 +73,8 @@ class FilesWidget(QListWidget):
         prev_item:
             the previous file item
         """
-        if prev_item is None:
-            self._annotator_model.set_previous_image_index(None)
-        else:
-            self._annotator_model.set_previous_image_index(self.row(prev_item))
-
-        if curr_item is None:
-            self._annotator_model.set_curr_img_index(None)
-        else:
-            self._annotator_model.set_curr_img_index(self.row(curr_item))
+        self._annotator_model.set_previous_image_index(self.row(prev_item))
+        self._annotator_model.set_curr_img_index(self.row(curr_item))
 
     def unhide_all(self) -> None:
         """Display the file names on all files in the list."""

--- a/napari_allencell_annotator/widgets/files_widget.py
+++ b/napari_allencell_annotator/widgets/files_widget.py
@@ -59,10 +59,7 @@ class FilesWidget(QListWidget):
 
     def _handle_image_changed(self):
         with QSignalBlocker(self):
-            if self._annotator_model.get_curr_img_index() is not None:
-                self.setCurrentItem(self.item(self._annotator_model.get_curr_img_index()))
-            else:
-                self.setCurrentItem(None)
+            self.setCurrentItem(self.item(self._annotator_model.get_curr_img_index()))
 
     def _handle_file_item_changed(self, curr_item: FileItem, prev_item: FileItem) -> None:
         """

--- a/napari_allencell_annotator/widgets/files_widget.py
+++ b/napari_allencell_annotator/widgets/files_widget.py
@@ -78,7 +78,10 @@ class FilesWidget(QListWidget):
         else:
             self._annotator_model.set_previous_image_index(self.row(prev_item))
 
-        self._annotator_model.set_curr_img_index(self.row(curr_item))
+        if curr_item is None:
+            self._annotator_model.set_curr_img_index(None)
+        else:
+            self._annotator_model.set_curr_img_index(self.row(curr_item))
 
 
     def unhide_all(self) -> None:

--- a/napari_allencell_annotator/widgets/files_widget.py
+++ b/napari_allencell_annotator/widgets/files_widget.py
@@ -83,7 +83,6 @@ class FilesWidget(QListWidget):
         else:
             self._annotator_model.set_curr_img_index(self.row(curr_item))
 
-
     def unhide_all(self) -> None:
         """Display the file names on all files in the list."""
         for i in range(self.count()):


### PR DESCRIPTION
<h2>Context</h2>
#67 The annotator widget doesn't react to changes made by the user in the file widget. Shuffling, deleting the current image, and deleting all images do not result in the current annotation being cleared from the UI. This can cause confusion to the user as the annotation is visible when no image selected is selected.

<h2>Changes</h2>

**annotation_model.py**

- `unselect_image` signal: Emitted when the current image index is set to None in `set_curr_img_index`. This happens when the user shuffles, deletes the current image, and deletes all images, which triggers `_handle_item_changed` and `set_curr_img_index`.

**annotation_view.py**

- Connect the `unselect_image` signal to `render_default_values` to set the currently displayed annotation to the default values.

**images_view.py**

- Connect the `unselect_image` signal to `self.viewer.clear_layers` to clear the current image shown in the viewer. Since now the viewer is updated through this signal, I removed lines that explicitly call `self.viewer.clear_layers` in the `_handle_shuffle_clicked`, `remove_image`, and `clear_all` methods.

**file_widget.py**
- `_handle_item_changed`: In `annotation_model.py`, `curr_img_index` is set to None before annotation starts. When the current item in the file widget is set to None, if I didn't have this line, `curr_img_index` would be set to -1 instead, which is inconsistent with the rest of the plugin and does not trigger `unselect_image`. I'm not sure if this is the best way to do it. Other solutions I can think of would be checking if `curr_img_index` is -1 in `set_curr_img_index` or changing the initialized value of `curr_img_index` to -1.

