### PR TITLE
66 order imported files

### DIFF
--- a/napari_allencell_annotator/util/file_utils.py
+++ b/napari_allencell_annotator/util/file_utils.py
@@ -42,9 +42,9 @@ class FileUtils:
         return extension in SUPPORTED_FILE_TYPES
 
     @staticmethod
-    def get_files_in_dir(dir_path: Path) -> list[Path]:
+    def get_sorted_files_in_dir(dir_path: Path) -> list[Path]:
         """
-        Return a list of paths to files in a directory.
+        Return a sorted list of paths to files in a directory.
 
         Parameters
         ----------

--- a/napari_allencell_annotator/util/file_utils.py
+++ b/napari_allencell_annotator/util/file_utils.py
@@ -51,7 +51,7 @@ class FileUtils:
         dir_path: list[Path]
             The path to a directory
         """
-        return list(dir_path.glob("*.*"))
+        return sorted(list(dir_path.glob("*.*")))
 
     @staticmethod
     def shuffle_file_list(files: list[Path]) -> list[Path]:

--- a/napari_allencell_annotator/view/images_view.py
+++ b/napari_allencell_annotator/view/images_view.py
@@ -231,7 +231,7 @@ class ImagesView(QFrame):
         dir_list : List[Path]
             The input list with dir[0] holding directory name.
         """
-        all_files_in_dir: list[Path] = FileUtils.get_files_in_dir(dir_path)
+        all_files_in_dir: list[Path] = FileUtils.get_sorted_files_in_dir(dir_path)
 
         if len(all_files_in_dir) < 1:
             self.viewer.alert("Folder is empty")

--- a/napari_allencell_annotator/view/main_view.py
+++ b/napari_allencell_annotator/view/main_view.py
@@ -155,8 +155,13 @@ class MainView(QFrame):
                         self._annotator_model.add_annotation(path, row[2:])
                     # self._images_view.add_new_item(path)
                 # start at row 0 if annotation data was not used from csv
+
                 file.close()
             self._annotator_model.set_all_images(image_list)
+            if shuffled:
+                self._annotator_model.set_shuffled_images(
+                    FileUtils.shuffle_file_list(self._annotator_model.get_all_images())
+                )
             self.annots.start_viewing(use_annots)
 
     def _shuffle_toggled(self, checked: bool):

--- a/napari_allencell_annotator/view/main_view.py
+++ b/napari_allencell_annotator/view/main_view.py
@@ -279,7 +279,7 @@ class MainView(QFrame):
                 if annot_path in old_images_list:
                     # if the annotation is complete move to front
                     if annot_list and len(annot_list) == len(self._annotator_model.get_annotation_keys()):
-                        new_images_list.insert(0, annot_path)
+                        new_images_list.insert(starting_idx, annot_path)
                         old_images_list.remove(annot_path)
                         starting_idx = starting_idx + 1
                     else:

--- a/napari_allencell_annotator/view/main_view.py
+++ b/napari_allencell_annotator/view/main_view.py
@@ -155,11 +155,14 @@ class MainView(QFrame):
                     # self._images_view.add_new_item(path)
                 # start at row 0 if annotation data was not used from csv
                 file.close()
-            self._annotator_model.set_all_images(image_list)
-            if shuffled:
-                self._annotator_model.set_shuffled_images(
-                    FileUtils.shuffle_file_list(self._annotator_model.get_all_images())
-                )
+                self._annotator_model.set_all_images(image_list)
+                if shuffled:
+                    self._annotator_model.set_shuffled_images(
+                        FileUtils.shuffle_file_list(self._annotator_model.get_all_images())
+                    )
+                else:
+                    self._annotator_model.set_shuffled_images(None)
+
             self.annots.start_viewing(use_annots)
 
     def _shuffle_toggled(self, checked: bool):

--- a/napari_allencell_annotator/view/main_view.py
+++ b/napari_allencell_annotator/view/main_view.py
@@ -155,7 +155,6 @@ class MainView(QFrame):
                         self._annotator_model.add_annotation(path, row[2:])
                     # self._images_view.add_new_item(path)
                 # start at row 0 if annotation data was not used from csv
-
                 file.close()
             self._annotator_model.set_all_images(image_list)
             if shuffled:

--- a/napari_allencell_annotator/view/main_view.py
+++ b/napari_allencell_annotator/view/main_view.py
@@ -133,8 +133,7 @@ class MainView(QFrame):
                 )
                 file = open(file_path)
                 reader = csv.reader(file)
-                shuffled: str = next(reader)[1]
-                # shuffled = self.str_to_bool(shuffled)
+                shuffled: bool = self.str_to_bool(next(reader)[1])
                 # annotation data header
                 annts = next(reader)[1]
                 # set annotation Key dict in model with json header info


### PR DESCRIPTION
<h2>Context</h2>
#66 The order of the image files imported from a directory using Add Folder... was random. We decided to order it alphabetically within each folder.

<h2>Changes</h2>

**file_utils.py**

- `get_files_in_dir()`: I added `sorted()` to sort the images alphabetically before returning them to the plugin.