### PR TITLE
65 shuffled when imported

### DIFF
--- a/napari_allencell_annotator/view/main_view.py
+++ b/napari_allencell_annotator/view/main_view.py
@@ -155,8 +155,13 @@ class MainView(QFrame):
                         self._annotator_model.add_annotation(path, row[2:])
                     # self._images_view.add_new_item(path)
                 # start at row 0 if annotation data was not used from csv
+
                 file.close()
             self._annotator_model.set_all_images(image_list)
+            if shuffled:
+                self._annotator_model.set_shuffled_images(
+                    FileUtils.shuffle_file_list(self._annotator_model.get_all_images())
+                )
             self.annots.start_viewing(use_annots)
 
     def _shuffle_toggled(self, checked: bool):

--- a/napari_allencell_annotator/view/main_view.py
+++ b/napari_allencell_annotator/view/main_view.py
@@ -279,7 +279,7 @@ class MainView(QFrame):
                 if annot_path in old_images_list:
                     # if the annotation is complete move to front
                     if annot_list and len(annot_list) == len(self._annotator_model.get_annotation_keys()):
-                        new_images_list.insert(0, annot_path)
+                        new_images_list.insert(starting_idx, annot_path)
                         old_images_list.remove(annot_path)
                         starting_idx = starting_idx + 1
                     else:

--- a/napari_allencell_annotator/view/main_view.py
+++ b/napari_allencell_annotator/view/main_view.py
@@ -155,11 +155,14 @@ class MainView(QFrame):
                     # self._images_view.add_new_item(path)
                 # start at row 0 if annotation data was not used from csv
                 file.close()
-            self._annotator_model.set_all_images(image_list)
-            if shuffled:
-                self._annotator_model.set_shuffled_images(
-                    FileUtils.shuffle_file_list(self._annotator_model.get_all_images())
-                )
+                self._annotator_model.set_all_images(image_list)
+                if shuffled:
+                    self._annotator_model.set_shuffled_images(
+                        FileUtils.shuffle_file_list(self._annotator_model.get_all_images())
+                    )
+                else:
+                    self._annotator_model.set_shuffled_images(None)
+
             self.annots.start_viewing(use_annots)
 
     def _shuffle_toggled(self, checked: bool):

--- a/napari_allencell_annotator/view/main_view.py
+++ b/napari_allencell_annotator/view/main_view.py
@@ -155,7 +155,6 @@ class MainView(QFrame):
                         self._annotator_model.add_annotation(path, row[2:])
                     # self._images_view.add_new_item(path)
                 # start at row 0 if annotation data was not used from csv
-
                 file.close()
             self._annotator_model.set_all_images(image_list)
             if shuffled:

--- a/napari_allencell_annotator/view/main_view.py
+++ b/napari_allencell_annotator/view/main_view.py
@@ -133,8 +133,7 @@ class MainView(QFrame):
                 )
                 file = open(file_path)
                 reader = csv.reader(file)
-                shuffled: str = next(reader)[1]
-                # shuffled = self.str_to_bool(shuffled)
+                shuffled: bool = self.str_to_bool(next(reader)[1])
                 # annotation data header
                 annts = next(reader)[1]
                 # set annotation Key dict in model with json header info


### PR DESCRIPTION
<h2>Context</h2>
#65 When the user imports a csv with the shuffled field = True, the imported images should be shuffled by default.

<h2>Changes</h2>

**main_view.py**

- `_csv_json_import_selected_evt()`: I added an if statement to check if the csv is shuffled. If so, it calls `set_shuffled_images` in` _annotator_model.py`. Before this PR, the code read whether the `shuffled` field has been set to True or not but didn't do anything after that.