### PR TITLE
53 Maintain annotated image order

### DIFF
--- a/napari_allencell_annotator/view/main_view.py
+++ b/napari_allencell_annotator/view/main_view.py
@@ -279,7 +279,7 @@ class MainView(QFrame):
                 if annot_path in old_images_list:
                     # if the annotation is complete move to front
                     if annot_list and len(annot_list) == len(self._annotator_model.get_annotation_keys()):
-                        new_images_list.insert(0, annot_path)
+                        new_images_list.insert(starting_idx, annot_path)
                         old_images_list.remove(annot_path)
                         starting_idx = starting_idx + 1
                     else:


### PR DESCRIPTION
<h2>Context</h2>
#53 The order of annotated images was reversed every time the user starts a new annotation session. We want to maintaining the same image order.

<h2>Changes</h2>

**main_view.py**

- `_setup_annotating()`: I inserted each new annotated image into the end of `old_images_list` instead of at the beginning. This results in the annotated images having the same order as before the user starts annotating.