### PR TITLE
63 not populate unannotated

### DIFF
--- a/napari_allencell_annotator/controller/annotator_controller.py
+++ b/napari_allencell_annotator/controller/annotator_controller.py
@@ -168,7 +168,11 @@ class AnnotatorController:
             path: Path = self._annotation_model.get_curr_img()
             # files_and_annots values are lists File Path ->[File Name, FMS, annot1val, annot2val ...]
             # if the file has not been annotated the list is just length 2 [File Name, FMS]
-            if path is None or path not in list(self._annotation_model.get_annotations().keys()) or len(self._annotation_model.get_annotations()[path]) == 0:
+            if (
+                path is None
+                or path not in list(self._annotation_model.get_annotations().keys())
+                or len(self._annotation_model.get_annotations()[path]) == 0
+            ):
                 # if the image is un-annotated render the default values or no image is selected
                 self.view.render_default_values()
             else:

--- a/napari_allencell_annotator/controller/annotator_controller.py
+++ b/napari_allencell_annotator/controller/annotator_controller.py
@@ -1,4 +1,3 @@
-import json
 from pathlib import Path
 
 from napari_allencell_annotator.model.annotation_model import AnnotatorModel
@@ -10,7 +9,7 @@ from napari_allencell_annotator.view.annotator_view import (
 )
 import napari
 
-from typing import Dict, List, Optional, Any
+from typing import List, Optional
 import csv
 
 

--- a/napari_allencell_annotator/controller/annotator_controller.py
+++ b/napari_allencell_annotator/controller/annotator_controller.py
@@ -168,7 +168,7 @@ class AnnotatorController:
             path: Path = self._annotation_model.get_curr_img()
             # files_and_annots values are lists File Path ->[File Name, FMS, annot1val, annot2val ...]
             # if the file has not been annotated the list is just length 2 [File Name, FMS]
-            if path is None or path not in list(self._annotation_model.get_annotations().keys()):
+            if path is None or path not in list(self._annotation_model.get_annotations().keys()) or len(self._annotation_model.get_annotations()[path]) == 0:
                 # if the image is un-annotated render the default values or no image is selected
                 self.view.render_default_values()
             else:

--- a/napari_allencell_annotator/model/annotation_model.py
+++ b/napari_allencell_annotator/model/annotation_model.py
@@ -1,15 +1,10 @@
-import json
-from enum import Enum
 from pathlib import Path
 from typing import Optional, Any
 
 from PyQt5.QtCore import QObject
 from qtpy.QtCore import Signal
 
-from napari_allencell_annotator.model.combo_key import ComboKey
 from napari_allencell_annotator.model.key import Key
-from napari_allencell_annotator.util.file_utils import FileUtils
-from napari_allencell_annotator.util.json_utils import JSONUtils
 
 
 class AnnotatorModel(QObject):

--- a/napari_allencell_annotator/util/image_utils.py
+++ b/napari_allencell_annotator/util/image_utils.py
@@ -5,7 +5,6 @@ from bioio import BioImage
 import bioio_ome_tiff
 import bioio_czi
 import bioio_imageio
-import napari
 
 
 class ImageUtils:

--- a/napari_allencell_annotator/view/annotator_view.py
+++ b/napari_allencell_annotator/view/annotator_view.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Dict, List, Optional, Any, Union
+from typing import Dict, List, Any
 
 from qtpy.QtWidgets import QFrame
 from qtpy import QtCore

--- a/napari_allencell_annotator/view/images_view.py
+++ b/napari_allencell_annotator/view/images_view.py
@@ -207,7 +207,6 @@ class ImagesView(QFrame):
             img: ImageUtils = ImageUtils(current)
             self.viewer.add_image(img.get_image_data())
 
-
     def update_num_files_label(self, num_files: int) -> None:
         """
         Update num_files_label to show the number of image files

--- a/napari_allencell_annotator/view/images_view.py
+++ b/napari_allencell_annotator/view/images_view.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-import random
 from typing import Optional
 
 from PyQt5.QtWidgets import QListWidgetItem
@@ -10,7 +9,6 @@ from napari_allencell_annotator.widgets.file_scrollable_popup import FileScrolla
 from napari_allencell_annotator.widgets.popup import Popup
 from qtpy.QtWidgets import QFrame
 from qtpy.QtCore import Qt
-from qtpy.QtCore import Signal
 
 from qtpy.QtWidgets import (
     QLabel,
@@ -27,7 +25,6 @@ from napari_allencell_annotator.widgets.file_input import (
 from napari_allencell_annotator.widgets.files_widget import FilesWidget, FileItem
 from napari_allencell_annotator.util.file_utils import FileUtils
 from napari_allencell_annotator._style import Style
-from napari_allencell_annotator.model.images_model import ImagesModel
 
 from napari_allencell_annotator.util.image_utils import ImageUtils
 

--- a/napari_allencell_annotator/view/main_view.py
+++ b/napari_allencell_annotator/view/main_view.py
@@ -1,5 +1,4 @@
 import csv
-import itertools
 from pathlib import Path
 
 from napari_allencell_annotator.model.annotation_model import AnnotatorModel
@@ -11,7 +10,6 @@ from qtpy.QtWidgets import QVBoxLayout, QDialog
 from qtpy.QtGui import QKeySequence
 
 from napari_allencell_annotator.controller.annotator_controller import AnnotatorController
-from napari_allencell_annotator.model.images_model import ImagesModel
 from napari_allencell_annotator.widgets.create_dialog import CreateDialog
 from napari_allencell_annotator.widgets.template_item import ItemType, TemplateItem
 from napari_allencell_annotator.widgets.popup import Popup
@@ -19,7 +17,7 @@ from napari_allencell_annotator.view.viewer import Viewer
 from napari_allencell_annotator.view.i_viewer import IViewer
 
 import napari
-from typing import List, Dict, Union, Any
+from typing import List, Union
 
 
 class MainView(QFrame):

--- a/napari_allencell_annotator/widgets/annotation_item.py
+++ b/napari_allencell_annotator/widgets/annotation_item.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Dict, List, Optional, Any
+from typing import Tuple, List, Optional, Any
 
 from qtpy.QtWidgets import QLayout
 from qtpy import QtWidgets

--- a/napari_allencell_annotator/widgets/annotation_widget.py
+++ b/napari_allencell_annotator/widgets/annotation_widget.py
@@ -1,5 +1,3 @@
-from typing import Dict, Any
-
 from qtpy.QtWidgets import QListWidget, QAbstractItemView
 from qtpy.QtCore import Signal
 

--- a/napari_allencell_annotator/widgets/create_dialog.py
+++ b/napari_allencell_annotator/widgets/create_dialog.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, Any
+from typing import Dict
 
 from napari_allencell_annotator._style import Style
 from qtpy import QtWidgets

--- a/napari_allencell_annotator/widgets/template_list.py
+++ b/napari_allencell_annotator/widgets/template_list.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any, List
+from typing import Any, List
 
 from qtpy import QtWidgets
 from qtpy.QtWidgets import QLineEdit, QCheckBox, QComboBox, QSpinBox


### PR DESCRIPTION
Note: I already fixed this issue in #64 but somehow it got reverted. So I'm fixing it again in this PR.

<h2>Context</h2>

#63 The unannotated images were populated with the recent values rendered, not the default values. This happened when the user viewed annotation or continued annotating after the first annotating session.

<h2>Changes</h2>
The plugin now checks if the annotation has been created as an empty list for an image. If so, it renders the default values.

