### PR TITLE
Fix failing remove tests

### DIFF
--- a/napari_allencell_annotator/_tests/view/images_view_test.py
+++ b/napari_allencell_annotator/_tests/view/images_view_test.py
@@ -226,13 +226,13 @@ def test_handle_shuffle_clicked_toggled_off(images_view: ImagesView, annotator_m
 def test_delete_checked(images_view: ImagesView, annotator_model: AnnotatorModel) -> None:
     # ARRANGE
     test_file_1: Path = Path(napari_allencell_annotator.__file__).parent / "_tests" / "assets" / "test_img1.tiff"
-    test_file_item_1: FileItem = FileItem(test_file_1, images_view.file_widget, False)
-
     test_file_2: Path = Path(napari_allencell_annotator.__file__).parent / "_tests" / "assets" / "test_img2.tiff"
-    test_file_item_2: FileItem = FileItem(test_file_2, images_view.file_widget, False)
+
+    annotator_model.set_all_images([test_file_1, test_file_2])
+    test_file_item_1: FileItem = images_view.file_widget.item(0)
+    test_file_item_2: FileItem = images_view.file_widget.item(1)
 
     images_view.file_widget.checked = {test_file_item_1, test_file_item_2}
-    annotator_model.set_all_images([test_file_1, test_file_2])
 
     # ACT
     images_view.delete_checked()
@@ -246,8 +246,9 @@ def test_delete_checked(images_view: ImagesView, annotator_model: AnnotatorModel
 def test_remove_image(images_view: ImagesView, annotator_model: AnnotatorModel) -> None:
     # ARRANGE
     test_file: Path = Path(napari_allencell_annotator.__file__).parent / "_tests" / "assets" / "test_img1.tiff"
+
     annotator_model.set_all_images([test_file])
-    test_file_item = images_view.file_widget.item(0)
+    test_file_item: FileItem = images_view.file_widget.item(0)
 
     # ACT
     images_view.remove_image(test_file_item)
@@ -279,13 +280,11 @@ def test_start_annotating_no_files(images_view: ImagesView) -> None:
     assert images_view.viewer.alerts[-1] == "No files to annotate"
 
 
-def test_start_annotating_with_files(images_view: ImagesView) -> None:
+def test_start_annotating_with_files(images_view: ImagesView, annotator_model: AnnotatorModel) -> None:
     # ARRANGE
     test_file_1: Path = Path(napari_allencell_annotator.__file__).parent / "_tests" / "assets" / "test_img1.tiff"
-    test_file_item_1: FileItem = FileItem(test_file_1, images_view.file_widget, False)
-
     test_file_2: Path = Path(napari_allencell_annotator.__file__).parent / "_tests" / "assets" / "test_img2.tiff"
-    test_file_item_2: FileItem = FileItem(test_file_2, images_view.file_widget, False)
+    annotator_model.set_all_images([test_file_1, test_file_2])
 
     # ACT
     images_view.start_annotating()

--- a/napari_allencell_annotator/_tests/view/images_view_test.py
+++ b/napari_allencell_annotator/_tests/view/images_view_test.py
@@ -246,8 +246,8 @@ def test_delete_checked(images_view: ImagesView, annotator_model: AnnotatorModel
 def test_remove_image(images_view: ImagesView, annotator_model: AnnotatorModel) -> None:
     # ARRANGE
     test_file: Path = Path(napari_allencell_annotator.__file__).parent / "_tests" / "assets" / "test_img1.tiff"
-    test_file_item: FileItem = FileItem(test_file, images_view.file_widget, False)
     annotator_model.set_all_images([test_file])
+    test_file_item = images_view.file_widget.item(0)
 
     # ACT
     images_view.remove_image(test_file_item)
@@ -260,7 +260,6 @@ def test_remove_image(images_view: ImagesView, annotator_model: AnnotatorModel) 
 def test_clear_all(images_view: ImagesView, annotator_model: AnnotatorModel) -> None:
     # ARRANGE
     test_file: Path = Path(napari_allencell_annotator.__file__).parent / "_tests" / "assets" / "test_img1.tiff"
-    test_file_item: FileItem = FileItem(test_file, images_view.file_widget, False)
     annotator_model.set_all_images([test_file])
 
     # ACT


### PR DESCRIPTION
<h2>Context</h2>

`test_delete_checked` and `test_remove_image` in `images_view_test.py` were failing. This was because in the test setup, each image file was added to both the file widget and the annotation model, respectively. However, the annotation model also sent a signal to update the file widget again, deleting the previous file item object, which was referenced by the code. Therefore, an error was raised when the code tried to delete the object.

<h2>Changes</h2>

I removed the lines adding images to the file widget and only add image files to the annotation model. By doing this, the annotation model automatically updates the file widget. File items are referenced directly from the file widget in the tests. I made the same changes to `test_clear_all` and `test_start_annotation_with_files`.