### PR TITLE
83 post point annotating

### DIFF
--- a/napari_allencell_annotator/_tests/controller/test_annotator_controller.py
+++ b/napari_allencell_annotator/_tests/controller/test_annotator_controller.py
@@ -1,0 +1,32 @@
+import pytest
+from napari_allencell_annotator._tests.fakes.fake_viewer import FakeViewer
+from napari_allencell_annotator.view.annotator_view import AnnotatorViewMode
+
+from napari_allencell_annotator.view.i_viewer import IViewer
+
+from napari_allencell_annotator.model.annotation_model import AnnotatorModel
+
+from napari_allencell_annotator.controller.annotator_controller import AnnotatorController
+
+
+@pytest.fixture
+def annotator_model(qtbot) -> AnnotatorModel:
+    return AnnotatorModel()
+
+
+@pytest.fixture
+def viewer(qtbot) -> IViewer:
+    return FakeViewer()
+
+
+@pytest.fixture
+def annotator_controller(qtbot, annotator_model: AnnotatorModel, viewer: IViewer) -> AnnotatorController:
+    return AnnotatorController(annotator_model, viewer)
+
+
+def test_start_annotating(annotator_controller: AnnotatorController) -> None:
+    # ACT
+    annotator_controller.start_annotating()
+
+    # ASSERT
+    assert annotator_controller.view.mode == AnnotatorViewMode.ANNOTATE

--- a/napari_allencell_annotator/_tests/controller/test_annotator_controller.py
+++ b/napari_allencell_annotator/_tests/controller/test_annotator_controller.py
@@ -1,32 +1,19 @@
-import pytest
 from napari_allencell_annotator._tests.fakes.fake_viewer import FakeViewer
 from napari_allencell_annotator.view.annotator_view import AnnotatorViewMode
-
-from napari_allencell_annotator.view.i_viewer import IViewer
-
-from napari_allencell_annotator.model.annotation_model import AnnotatorModel
-
 from napari_allencell_annotator.controller.annotator_controller import AnnotatorController
+from napari_allencell_annotator.view.main_view import MainView
+
+import pytest
+from pytestqt import qtbot
 
 
-@pytest.fixture
-def annotator_model(qtbot) -> AnnotatorModel:
-    return AnnotatorModel()
 
+def test_start_annotating(qtbot) -> None:
+    # ARRANGE
+    main_view_simulated: MainView = MainView(FakeViewer())
+    qtbot.add_widget(main_view_simulated)
+    annotator_controller: AnnotatorController = main_view_simulated.annots
 
-@pytest.fixture
-def viewer(qtbot) -> IViewer:
-    return FakeViewer()
-
-
-@pytest.fixture
-def annotator_controller(qtbot, annotator_model: AnnotatorModel, viewer: IViewer) -> AnnotatorController:
-    annotator_controller_fixture = AnnotatorController(annotator_model, viewer)
-    annotator_controller_fixture.view.hide()
-    return annotator_controller_fixture
-
-
-def test_start_annotating(annotator_controller: AnnotatorController) -> None:
     # ACT
     annotator_controller.start_annotating()
 

--- a/napari_allencell_annotator/_tests/controller/test_annotator_controller.py
+++ b/napari_allencell_annotator/_tests/controller/test_annotator_controller.py
@@ -21,7 +21,9 @@ def viewer(qtbot) -> IViewer:
 
 @pytest.fixture
 def annotator_controller(qtbot, annotator_model: AnnotatorModel, viewer: IViewer) -> AnnotatorController:
-    return AnnotatorController(annotator_model, viewer)
+    annotator_controller_fixture = AnnotatorController(annotator_model, viewer)
+    annotator_controller_fixture.view.hide()
+    return annotator_controller_fixture
 
 
 def test_start_annotating(annotator_controller: AnnotatorController) -> None:

--- a/napari_allencell_annotator/_tests/controller/test_annotator_controller.py
+++ b/napari_allencell_annotator/_tests/controller/test_annotator_controller.py
@@ -7,7 +7,6 @@ import pytest
 from pytestqt import qtbot
 
 
-
 def test_start_annotating(qtbot) -> None:
     # ARRANGE
     main_view_simulated: MainView = MainView(FakeViewer())

--- a/napari_allencell_annotator/_tests/fakes/fake_viewer.py
+++ b/napari_allencell_annotator/_tests/fakes/fake_viewer.py
@@ -29,7 +29,7 @@ class FakeViewer(IViewer):
     def get_all_points_layers(self) -> List[Points]:
         return [layer for layer in self.get_layers() if isinstance(layer, Points)]
 
-    def create_points_layer(self, name: str, color: str, visible: bool, data: np.ndarray = None) -> Points:
+    def create_points_layer(self, name: str, visible: bool, data: np.ndarray = None) -> Points:
         points: Points = Points(data=data, name=name, color=color, visible=visible, ndim=6)
         self._layers.append(points)
         return points

--- a/napari_allencell_annotator/_tests/fakes/fake_viewer.py
+++ b/napari_allencell_annotator/_tests/fakes/fake_viewer.py
@@ -31,7 +31,7 @@ class FakeViewer(IViewer):
         return [layer for layer in self.get_layers() if isinstance(layer, Points)]
 
     def create_points_layer(self, name: str, visible: bool, data: np.ndarray = None) -> Points:
-        points: Points = Points(data=data, name=name, color=color, visible=visible, ndim=6)
+        points: Points = Points(data=data, name=name, visible=visible, ndim=6)
         self._layers.append(points)
         return points
 

--- a/napari_allencell_annotator/_tests/fakes/fake_viewer.py
+++ b/napari_allencell_annotator/_tests/fakes/fake_viewer.py
@@ -53,17 +53,17 @@ class FakeViewer(IViewer):
 
         return all_point_annotations
 
-    def toggle_points_layer(self, annot_points_layer: Points):
+    def toggle_points_layer(self, annot_points_layer: Points) -> None:
         if self.get_points_layer_mode(annot_points_layer) == PointsLayerMode.PAN_ZOOM.value:
             self.set_all_points_layer_to_pan_zoom()
             self.set_points_layer_mode(annot_points_layer, PointsLayerMode.ADD)
-            self._layers_selection = []
+            self._layers_selection: list[Layer] = []
             self._layers_selection.append(annot_points_layer)
         else:
             annot_points_layer.selected_data = []
             self.set_points_layer_mode(annot_points_layer, PointsLayerMode.PAN_ZOOM)
 
-    def set_all_points_layer_to_pan_zoom(self):
+    def set_all_points_layer_to_pan_zoom(self) -> None:
         for points_layer in self.get_all_points_layers():
             self.set_points_layer_mode(points_layer, PointsLayerMode.PAN_ZOOM)
             points_layer.selected_data = []

--- a/napari_allencell_annotator/_tests/fakes/fake_viewer.py
+++ b/napari_allencell_annotator/_tests/fakes/fake_viewer.py
@@ -4,6 +4,7 @@ import numpy as np
 from napari.layers import Layer, Points
 
 from napari_allencell_annotator.view.i_viewer import IViewer
+from napari_allencell_annotator.view.viewer import PointsLayerMode
 
 
 class FakeViewer(IViewer):
@@ -32,6 +33,12 @@ class FakeViewer(IViewer):
         points: Points = Points(data=data, name=name, color=color, visible=visible, ndim=6)
         self._layers.append(points)
         return points
+
+    def set_points_layer_mode(self, points_layer: Points, mode: PointsLayerMode) -> None:
+        points_layer.mode = mode.value
+
+    def get_points_layer_mode(self, points_layer: Points) -> str:
+        return points_layer.mode
 
     def get_selected_points(self, point_layer: Points) -> List[Tuple]:
         return list(map(tuple, point_layer.data))

--- a/napari_allencell_annotator/_tests/fakes/fake_viewer.py
+++ b/napari_allencell_annotator/_tests/fakes/fake_viewer.py
@@ -13,6 +13,7 @@ class FakeViewer(IViewer):
 
         self._layers = []
         self.alerts = []
+        self._layers_selection = []
 
     def add_image(self, image: np.ndarray) -> None:
         self._layers.append(image)
@@ -51,3 +52,18 @@ class FakeViewer(IViewer):
             all_point_annotations[points_layer.name] = self.get_selected_points(points_layer)
 
         return all_point_annotations
+
+    def toggle_points_layer(self, annot_points_layer: Points):
+        if self.get_points_layer_mode(annot_points_layer) == PointsLayerMode.PAN_ZOOM.value:
+            self.set_all_points_layer_to_pan_zoom()
+            self.set_points_layer_mode(annot_points_layer, PointsLayerMode.ADD)
+            self._layers_selection = []
+            self._layers_selection.append(annot_points_layer)
+        else:
+            annot_points_layer.selected_data = []
+            self.set_points_layer_mode(annot_points_layer, PointsLayerMode.PAN_ZOOM)
+
+    def set_all_points_layer_to_pan_zoom(self):
+        for points_layer in self.get_all_points_layers():
+            self.set_points_layer_mode(points_layer, PointsLayerMode.PAN_ZOOM)
+            points_layer.selected_data = []

--- a/napari_allencell_annotator/_tests/view/annotator_view_test.py
+++ b/napari_allencell_annotator/_tests/view/annotator_view_test.py
@@ -98,16 +98,16 @@ class TestAnnotatorView:
         item2.set_value.assert_called_once_with("val2")
         item3.set_default_value.assert_called_once_with()
 
-    def test_get_curr_annots(self):
-        item1 = create_autospec(TemplateItem)
-        item1.get_value = MagicMock(return_value="ret1")
-        item2 = create_autospec(TemplateItem)
-        item2.get_value = MagicMock(return_value="ret2")
-        item3 = create_autospec(TemplateItem)
-        item3.get_value = MagicMock(return_value="ret3")
-        self._view.annot_list = create_autospec(TemplateList)
-        self._view.annot_list.items = [item1, item2, item3]
-        assert self._view.get_curr_annots() == ["ret1", "ret2", "ret3"]
+    # def test_get_curr_annots(self):
+    #     item1 = create_autospec(TemplateItem)
+    #     item1.get_value = MagicMock(return_value="ret1")
+    #     item2 = create_autospec(TemplateItem)
+    #     item2.get_value = MagicMock(return_value="ret2")
+    #     item3 = create_autospec(TemplateItem)
+    #     item3.get_value = MagicMock(return_value="ret3")
+    #     self._view.annot_list = create_autospec(TemplateList)
+    #     self._view.annot_list.items = [item1, item2, item3]
+    #     assert self._view.get_curr_annots() == ["ret1", "ret2", "ret3"]
 
     def test_display_mode_add_mode(self):
         self._view._mode = AnnotatorViewMode.ADD

--- a/napari_allencell_annotator/_tests/view/annotator_view_test.py
+++ b/napari_allencell_annotator/_tests/view/annotator_view_test.py
@@ -34,13 +34,9 @@ def viewer(qtbot) -> IViewer:
     return FakeViewer()
 
 
-@pytest.fixture
-def annotator_view(qtbot, annotator_model: AnnotatorModel, viewer: IViewer) -> AnnotatorView:
-    return AnnotatorView(annotator_model, viewer)
-
-
-def test_render_values(annotator_view: AnnotatorView) -> None:
+def test_render_values(annotator_model: AnnotatorModel, viewer: IViewer) -> None:
     # ARRANGE
+    annotator_view: AnnotatorView = AnnotatorView(annotator_model, viewer)
     annotator_view.annot_list.add_item("text", Key("string", "text"))
     annotator_view.annot_list.add_item("number", Key("number", 1))
     annotator_view.annot_list.add_item("point_created", Key("point", None))
@@ -54,9 +50,10 @@ def test_render_values(annotator_view: AnnotatorView) -> None:
     assert "point_created" in annotator_view._annotator_model.get_all_curr_img_points_layers()
 
 
-def test_get_curr_annots(annotator_view: AnnotatorView) -> None:
+def test_get_curr_annots(annotator_model: AnnotatorModel, viewer: IViewer) -> None:
 
     # ARRANGE
+    annotator_view: AnnotatorView = AnnotatorView(annotator_model, viewer)
     annotator_view.annot_list.add_item("text", Key("string", ""))
     annotator_view.annot_list.add_item("number", Key("number", 1))
     annotator_view.annot_list.add_item("bool", Key("bool", True))

--- a/napari_allencell_annotator/_tests/view/annotator_view_test.py
+++ b/napari_allencell_annotator/_tests/view/annotator_view_test.py
@@ -46,20 +46,12 @@ def test_get_curr_annots(annotator_view: AnnotatorView) -> None:
     annotator_view.annot_list.add_item("number", Key("number", 1))
     annotator_view.annot_list.add_item("bool", Key("bool", True))
     annotator_view.annot_list.add_item("list", ComboKey("list", ["a", "b", "c"], "a"))
-    annotator_view.annot_list.add_item("point", Key("point_created", None))
-    annotator_view.annot_list.add_item("point", Key("point_none", None))
+    annotator_view.annot_list.add_item("point_created", Key("point", None))
+    annotator_view.annot_list.add_item("point_none", Key("point", None))
     annotator_view.viewer.create_points_layer("point_created", True, [(0, 0, 0, 0, 0, 0)])
-    print(annotator_view.viewer.get_all_point_annotations())
-
-    # add create points
-    assert annotator_view.get_curr_annots() == ["", 1, True, "a", [(0, 0, 0, 0, 0, 0)], None]
-
-    # annotator_view.annot_list.item(0).set_value("")
-    # annotator_view.annot_list.item(1).set_value(1)
-    # annotator_view.annot_list.item(2).set_value(True)
-    # annotator_view.annot_list.item().set_value("text")
 
     # ASSERT
+    assert annotator_view.get_curr_annots() == ["", 1, True, "a", [(0, 0, 0, 0, 0, 0)], None]
 
 
 class TestAnnotatorView:

--- a/napari_allencell_annotator/_tests/view/annotator_view_test.py
+++ b/napari_allencell_annotator/_tests/view/annotator_view_test.py
@@ -54,8 +54,6 @@ def test_render_values(annotator_view: AnnotatorView) -> None:
     assert "point_created" in annotator_view._annotator_model.get_all_curr_img_points_layers()
 
 
-
-
 def test_get_curr_annots(annotator_view: AnnotatorView) -> None:
 
     # ARRANGE

--- a/napari_allencell_annotator/_tests/view/annotator_view_test.py
+++ b/napari_allencell_annotator/_tests/view/annotator_view_test.py
@@ -1,6 +1,18 @@
 from unittest import mock
 from unittest.mock import MagicMock, create_autospec
 
+import pytest
+
+from napari_allencell_annotator.model.combo_key import ComboKey
+
+from napari_allencell_annotator.model.key import Key
+
+from napari_allencell_annotator.view.i_viewer import IViewer
+
+from napari_allencell_annotator._tests.fakes.fake_viewer import FakeViewer
+
+from napari_allencell_annotator.model.annotation_model import AnnotatorModel
+
 from napari_allencell_annotator.view.annotator_view import (
     AnnotatorView,
     AnnotatorViewMode,
@@ -10,6 +22,44 @@ from napari_allencell_annotator.view.annotator_view import (
     QScrollArea,
 )
 from napari_allencell_annotator.widgets.template_item import TemplateItem
+
+
+@pytest.fixture
+def annotator_model(qtbot) -> AnnotatorModel:
+    return AnnotatorModel()
+
+
+@pytest.fixture
+def viewer(qtbot) -> IViewer:
+    return FakeViewer()
+
+
+@pytest.fixture
+def annotator_view(qtbot, annotator_model: AnnotatorModel, viewer: IViewer) -> AnnotatorView:
+    return AnnotatorView(annotator_model, viewer)
+
+
+def test_get_curr_annots(annotator_view: AnnotatorView) -> None:
+
+    # ACT
+    annotator_view.annot_list.add_item("text", Key("string", ""))
+    annotator_view.annot_list.add_item("number", Key("number", 1))
+    annotator_view.annot_list.add_item("bool", Key("bool", True))
+    annotator_view.annot_list.add_item("list", ComboKey("list", ["a", "b", "c"], "a"))
+    annotator_view.annot_list.add_item("point", Key("point_created", None))
+    annotator_view.annot_list.add_item("point", Key("point_none", None))
+    annotator_view.viewer.create_points_layer("point_created", True, [(0, 0, 0, 0, 0, 0)])
+    print(annotator_view.viewer.get_all_point_annotations())
+
+    # add create points
+    assert annotator_view.get_curr_annots() == ["", 1, True, "a", [(0, 0, 0, 0, 0, 0)], None]
+
+    # annotator_view.annot_list.item(0).set_value("")
+    # annotator_view.annot_list.item(1).set_value(1)
+    # annotator_view.annot_list.item(2).set_value(True)
+    # annotator_view.annot_list.item().set_value("text")
+
+    # ASSERT
 
 
 class TestAnnotatorView:

--- a/napari_allencell_annotator/_tests/view/annotator_view_test.py
+++ b/napari_allencell_annotator/_tests/view/annotator_view_test.py
@@ -39,9 +39,26 @@ def annotator_view(qtbot, annotator_model: AnnotatorModel, viewer: IViewer) -> A
     return AnnotatorView(annotator_model, viewer)
 
 
-def test_get_curr_annots(annotator_view: AnnotatorView) -> None:
+def test_render_values(annotator_view: AnnotatorView) -> None:
+    # ARRANGE
+    annotator_view.annot_list.add_item("text", Key("string", "text"))
+    annotator_view.annot_list.add_item("number", Key("number", 1))
+    annotator_view.annot_list.add_item("point_created", Key("point", None))
 
     # ACT
+    annotator_view.render_values(["", 2, [(0, 0, 0, 0, 0, 0)]])
+
+    # ASSERT
+    assert annotator_view.annot_list.item(0).editable_widget.text() == "text"
+    assert annotator_view.annot_list.item(1).editable_widget.value() == 2
+    assert "point_created" in annotator_view._annotator_model.get_all_curr_img_points_layers()
+
+
+
+
+def test_get_curr_annots(annotator_view: AnnotatorView) -> None:
+
+    # ARRANGE
     annotator_view.annot_list.add_item("text", Key("string", ""))
     annotator_view.annot_list.add_item("number", Key("number", 1))
     annotator_view.annot_list.add_item("bool", Key("bool", True))

--- a/napari_allencell_annotator/_tests/view/viewer_test.py
+++ b/napari_allencell_annotator/_tests/view/viewer_test.py
@@ -98,6 +98,7 @@ def test_get_all_point_annotations(viewer: Viewer) -> None:
     # ASSERT
     assert all_point_annotations == {"test1": [(0, 0)], "test2": [(1, 1)]}
 
+
 def test_toggle_points_layer_pan_zoom(viewer: Viewer) -> None:
     # ARRANGE
     test_points_layer_pan_zoom: Points = viewer.create_points_layer("pan_zoom", True, np.zeros(shape=(1, 2)))

--- a/napari_allencell_annotator/_tests/view/viewer_test.py
+++ b/napari_allencell_annotator/_tests/view/viewer_test.py
@@ -15,8 +15,8 @@ def viewer(make_napari_viewer: napari.Viewer) -> Viewer:
 def test_get_all_points_layer(viewer: Viewer) -> None:
     # ARRANGE
     viewer.add_image(np.zeros(shape=(2, 2)))
-    test_points_layer1: Points = viewer.create_points_layer("test1", "blue", True)
-    test_points_layer2: Points = viewer.create_points_layer("test2", "blue", True)
+    test_points_layer1: Points = viewer.create_points_layer("test1", True)
+    test_points_layer2: Points = viewer.create_points_layer("test2", True)
 
     # ACT
     all_points_layer: list[Points] = viewer.get_all_points_layers()
@@ -43,7 +43,7 @@ def test_create_points_layer(viewer: Viewer) -> None:
     test_points_data = np.zeros(shape=(1, 2))
 
     # ACT
-    test_points_layer: Points = viewer.create_points_layer("test", "blue", True, test_points_data)
+    test_points_layer: Points = viewer.create_points_layer("test", True, test_points_data)
 
     # ASSERT
     assert test_points_layer in viewer.get_all_points_layers()
@@ -57,7 +57,7 @@ def test_create_points_layer(viewer: Viewer) -> None:
 
 def test_set_points_layer_mode(viewer: Viewer) -> None:
     # ARRANGE
-    test_points_layer: Points = viewer.create_points_layer("test", "blue", True)
+    test_points_layer: Points = viewer.create_points_layer("test", True)
 
     # ACT
     viewer.set_points_layer_mode(test_points_layer, PointsLayerMode.ADD)
@@ -68,7 +68,7 @@ def test_set_points_layer_mode(viewer: Viewer) -> None:
 
 def test_get_selected_points(viewer: Viewer) -> None:
     # ARRANGE
-    test_points_layer: Points = viewer.create_points_layer("test", "blue", True, np.array([np.zeros(2), np.ones(2)]))
+    test_points_layer: Points = viewer.create_points_layer("test", True, np.array([np.zeros(2), np.ones(2)]))
 
     # ACT
     selected_points: list[tuple] = viewer.get_selected_points(test_points_layer)
@@ -79,8 +79,8 @@ def test_get_selected_points(viewer: Viewer) -> None:
 
 def test_get_all_point_annotations(viewer: Viewer) -> None:
     # ARRANGE
-    test_points_layer1: Points = viewer.create_points_layer("test1", "blue", True, np.zeros(shape=(1, 2)))
-    test_points_layer2: Points = viewer.create_points_layer("test2", "blue", True, np.ones(shape=(1, 2)))
+    test_points_layer1: Points = viewer.create_points_layer("test1", True, np.zeros(shape=(1, 2)))
+    test_points_layer2: Points = viewer.create_points_layer("test2", True, np.ones(shape=(1, 2)))
 
     # ACT
     all_point_annotations: dict[str, list[tuple]] = viewer.get_all_point_annotations()

--- a/napari_allencell_annotator/_tests/view/viewer_test.py
+++ b/napari_allencell_annotator/_tests/view/viewer_test.py
@@ -124,3 +124,20 @@ def test_toggle_points_layer_add(viewer: Viewer) -> None:
     # ASSERT
     assert len(test_points_layer_add.selected_data) == 0
     assert viewer.get_points_layer_mode(test_points_layer_add) == "pan_zoom"
+
+
+def test_set_all_points_layer_to_pan_zoom(viewer: Viewer) -> None:
+    # ARRANGE
+    test_points_layer_add1: Points = viewer.create_points_layer("add1", True, np.zeros(shape=(1, 2)))
+    test_points_layer_add2: Points = viewer.create_points_layer("add2", True, np.zeros(shape=(1, 2)))
+    viewer.set_points_layer_mode(test_points_layer_add1, PointsLayerMode.ADD)
+    viewer.set_points_layer_mode(test_points_layer_add2, PointsLayerMode.ADD)
+
+    # ACT
+    viewer.set_all_points_layer_to_pan_zoom()
+
+    # ASSERT
+    assert viewer.get_points_layer_mode(test_points_layer_add1) == "pan_zoom"
+    assert len(test_points_layer_add1.selected_data) == 0
+    assert viewer.get_points_layer_mode(test_points_layer_add2) == "pan_zoom"
+    assert len(test_points_layer_add2.selected_data) == 0

--- a/napari_allencell_annotator/_tests/view/viewer_test.py
+++ b/napari_allencell_annotator/_tests/view/viewer_test.py
@@ -49,7 +49,7 @@ def test_create_points_layer(viewer: Viewer) -> None:
     assert test_points_layer in viewer.get_all_points_layers()
     assert len(viewer.get_all_points_layers()) == 1
     assert test_points_layer.name == "test"
-    np.testing.assert_array_equal(test_points_layer.face_color[0], Colormap("blue").colors[0])
+    np.testing.assert_array_equal(test_points_layer.face_color[0], Colormap("lime").colors[0])
     assert test_points_layer.visible
     np.testing.assert_array_equal(test_points_layer.data, test_points_data)
     assert test_points_layer.ndim == 2

--- a/napari_allencell_annotator/_tests/view/viewer_test.py
+++ b/napari_allencell_annotator/_tests/view/viewer_test.py
@@ -43,16 +43,15 @@ def test_create_points_layer(viewer: Viewer) -> None:
     test_points_data = np.zeros(shape=(1, 2))
 
     # ACT
-    test_points_layer: Points = viewer.create_points_layer("test", True, test_points_data)
+    test_points_layer1: Points = viewer.create_points_layer("test1", True, test_points_data)
+    test_points_layer2: Points = viewer.create_points_layer("test2", True, test_points_data)
 
     # ASSERT
-    assert test_points_layer in viewer.get_all_points_layers()
-    assert len(viewer.get_all_points_layers()) == 1
-    assert test_points_layer.name == "test"
-    np.testing.assert_array_equal(test_points_layer.face_color[0], Colormap("lime").colors[0])
-    assert test_points_layer.visible
-    np.testing.assert_array_equal(test_points_layer.data, test_points_data)
-    assert test_points_layer.ndim == 2
+    assert test_points_layer1 in viewer.get_all_points_layers()
+    assert test_points_layer2 in viewer.get_all_points_layers()
+    np.testing.assert_array_equal(test_points_layer1.face_color[0], Colormap("lime").colors[0])
+    np.testing.assert_array_equal(test_points_layer2.face_color[0], Colormap("fuchsia").colors[0])
+
 
 
 def test_set_points_layer_mode(viewer: Viewer) -> None:

--- a/napari_allencell_annotator/_tests/view/viewer_test.py
+++ b/napari_allencell_annotator/_tests/view/viewer_test.py
@@ -53,7 +53,6 @@ def test_create_points_layer(viewer: Viewer) -> None:
     np.testing.assert_array_equal(test_points_layer2.face_color[0], Colormap("fuchsia").colors[0])
 
 
-
 def test_set_points_layer_mode(viewer: Viewer) -> None:
     # ARRANGE
     test_points_layer: Points = viewer.create_points_layer("test", True)
@@ -63,6 +62,18 @@ def test_set_points_layer_mode(viewer: Viewer) -> None:
 
     # ASSERT
     assert test_points_layer.mode == PointsLayerMode.ADD.value
+
+
+def test_get_points_layer_mode(viewer: Viewer) -> None:
+    # ARRANGE
+    test_points_layer: Points = viewer.create_points_layer("test", True)
+
+    # ACT
+    mode: str = viewer.get_points_layer_mode(test_points_layer)
+
+    # ASSERT
+    # default mode is pan_zoom
+    assert mode == "pan_zoom"
 
 
 def test_get_selected_points(viewer: Viewer) -> None:
@@ -86,3 +97,29 @@ def test_get_all_point_annotations(viewer: Viewer) -> None:
 
     # ASSERT
     assert all_point_annotations == {"test1": [(0, 0)], "test2": [(1, 1)]}
+
+def test_toggle_points_layer_pan_zoom(viewer: Viewer) -> None:
+    # ARRANGE
+    test_points_layer_pan_zoom: Points = viewer.create_points_layer("pan_zoom", True, np.zeros(shape=(1, 2)))
+    test_points_layer_other: Points = viewer.create_points_layer("other", True, np.ones(shape=(1, 2)))
+
+    # ACT
+    viewer.toggle_points_layer(test_points_layer_pan_zoom)
+
+    # ASSERT
+    assert viewer.get_points_layer_mode(test_points_layer_pan_zoom) == "add"
+    assert viewer.get_points_layer_mode(test_points_layer_other) == "pan_zoom"
+    assert viewer.viewer.layers.selection.pop() == test_points_layer_pan_zoom
+
+
+def test_toggle_points_layer_add(viewer: Viewer) -> None:
+    # ARRANGE
+    test_points_layer_add: Points = viewer.create_points_layer("add", True, np.zeros(shape=(1, 2)))
+    viewer.set_points_layer_mode(test_points_layer_add, PointsLayerMode.ADD)
+
+    # ACT
+    viewer.toggle_points_layer(test_points_layer_add)
+
+    # ASSERT
+    assert len(test_points_layer_add.selected_data) == 0
+    assert viewer.get_points_layer_mode(test_points_layer_add) == "pan_zoom"

--- a/napari_allencell_annotator/_tests/widgets/template_item_test.py
+++ b/napari_allencell_annotator/_tests/widgets/template_item_test.py
@@ -101,28 +101,28 @@ class TestTemplateItem:
         self._item._type = ItemType.STRING
         self._item.editable_widget = create_autospec(QLineEdit)
         self._item.editable_widget.textEdited.connect = MagicMock()
-        self._item.create_evt_listener()
+        self._item._create_evt_listener()
         self._item.editable_widget.textEdited.connect.assert_called_once()
 
     def test_create_evt_listener_num(self):
         self._item._type = ItemType.NUMBER
         self._item.editable_widget = create_autospec(QSpinBox)
         self._item.editable_widget.valueChanged.connect = MagicMock()
-        self._item.create_evt_listener()
+        self._item._create_evt_listener()
         self._item.editable_widget.valueChanged.connect.assert_called_once()
 
     def test_create_evt_listener_bool(self):
         self._item._type = ItemType.BOOL
         self._item.editable_widget = create_autospec(QCheckBox)
         self._item.editable_widget.stateChanged.connect = MagicMock()
-        self._item.create_evt_listener()
+        self._item._create_evt_listener()
         self._item.editable_widget.stateChanged.connect.assert_called_once()
 
     def test_create_evt_listener_list(self):
         self._item._type = ItemType.LIST
         self._item.editable_widget = create_autospec(QComboBox)
         self._item.editable_widget.activated.connect = MagicMock()
-        self._item.create_evt_listener()
+        self._item._create_evt_listener()
         self._item.editable_widget.activated.connect.assert_called_once()
 
     def test_set_focus_str(self):

--- a/napari_allencell_annotator/_tests/widgets/template_list_test.py
+++ b/napari_allencell_annotator/_tests/widgets/template_list_test.py
@@ -168,9 +168,9 @@ class TestTemplateList:
         item3 = create_autospec(TemplateItem)
         self._list._items = [item1, item2, item3]
         self._list.create_evt_listeners()
-        item1.create_evt_listener.assert_called_once_with()
-        item2.create_evt_listener.assert_called_once_with()
-        item3.create_evt_listener.assert_called_once_with()
+        item1._create_evt_listener.assert_called_once_with()
+        item2._create_evt_listener.assert_called_once_with()
+        item3._create_evt_listener.assert_called_once_with()
 
     def test_clear_all(self):
         self._list._items = ["item"]

--- a/napari_allencell_annotator/_tests/widgets/template_list_test.py
+++ b/napari_allencell_annotator/_tests/widgets/template_list_test.py
@@ -18,9 +18,11 @@ from napari_allencell_annotator.widgets.template_list import (
 )
 import pytest
 
+
 @pytest.fixture()
 def annotator_model(qtbot) -> AnnotatorModel:
     return AnnotatorModel()
+
 
 @pytest.fixture()
 def template_list(qtbot, annotator_model: AnnotatorModel) -> TemplateList:

--- a/napari_allencell_annotator/_tests/widgets/template_list_test.py
+++ b/napari_allencell_annotator/_tests/widgets/template_list_test.py
@@ -162,15 +162,15 @@ class TestTemplateList:
         self._list.prev_item()
         self._list.setCurrentRow.assert_called_once_with(0)
 
-    def test_create_evt_listeners(self):
-        item1 = create_autospec(TemplateItem)
-        item2 = create_autospec(TemplateItem)
-        item3 = create_autospec(TemplateItem)
-        self._list._items = [item1, item2, item3]
-        self._list.create_evt_listeners()
-        item1._create_evt_listener.assert_called_once_with()
-        item2._create_evt_listener.assert_called_once_with()
-        item3._create_evt_listener.assert_called_once_with()
+    # def test_create_evt_listeners(self):
+    #     item1 = create_autospec(TemplateItem)
+    #     item2 = create_autospec(TemplateItem)
+    #     item3 = create_autospec(TemplateItem)
+    #     self._list._items = [item1, item2, item3]
+    #     self._list.create_evt_listeners()
+    #     item1._create_evt_listener.assert_called_once_with()
+    #     item2._create_evt_listener.assert_called_once_with()
+    #     item3._create_evt_listener.assert_called_once_with()
 
     def test_clear_all(self):
         self._list._items = ["item"]

--- a/napari_allencell_annotator/_tests/widgets/template_list_test.py
+++ b/napari_allencell_annotator/_tests/widgets/template_list_test.py
@@ -2,6 +2,7 @@ from unittest import mock
 from unittest.mock import MagicMock, patch, create_autospec
 
 from PyQt5.QtWidgets import QPushButton, QLineEdit
+from napari_allencell_annotator.model.annotation_model import AnnotatorModel
 
 from napari_allencell_annotator.model.combo_key import ComboKey
 
@@ -17,10 +18,13 @@ from napari_allencell_annotator.widgets.template_list import (
 )
 import pytest
 
+@pytest.fixture()
+def annotator_model(qtbot) -> AnnotatorModel:
+    return AnnotatorModel()
 
 @pytest.fixture()
-def template_list(qtbot) -> TemplateList:
-    return TemplateList()
+def template_list(qtbot, annotator_model: AnnotatorModel) -> TemplateList:
+    return TemplateList(annotator_model)
 
 
 def test_add_item_string(template_list: TemplateList) -> None:

--- a/napari_allencell_annotator/controller/annotator_controller.py
+++ b/napari_allencell_annotator/controller/annotator_controller.py
@@ -211,9 +211,13 @@ class AnnotatorController:
                 self._annotation_model.get_all_images()[record_idx], self.view.get_curr_annots()
             )
             # self._annotation_model.clear_all_cur_img_points_layers()
+
+        # if the user changes to another image, send the annotation_recorded signal to clear all layers and
+        # display the new image after recording annotation.
         if record_idx == self._annotation_model.get_previous_image_index():
             self._annotation_model.annotation_saved()
 
+        # after recording annotations, not annotation item should be selected.
         self.view.annot_list.setCurrentItem(None)
 
     def read_json(self, file_path: Path):

--- a/napari_allencell_annotator/controller/annotator_controller.py
+++ b/napari_allencell_annotator/controller/annotator_controller.py
@@ -135,7 +135,6 @@ class AnnotatorController:
         self.write_csv()
         # reset optional fields in model to None (pre-annottion state)
         self._annotation_model.set_annotation_started(False)
-        self.view.viewer.set_all_points_layer_to_pan_zoom()
         self._annotation_model.set_csv_save_path(None)
         self.view.set_mode(AnnotatorViewMode.VIEW)
 

--- a/napari_allencell_annotator/controller/annotator_controller.py
+++ b/napari_allencell_annotator/controller/annotator_controller.py
@@ -211,6 +211,7 @@ class AnnotatorController:
             self._annotation_model.add_annotation(
                 self._annotation_model.get_all_images()[record_idx], self.view.get_curr_annots()
             )
+            self._annotation_model.clear_all_cur_img_points_layers()
 
     def read_json(self, file_path: Path):
         # TODO change param to path

--- a/napari_allencell_annotator/controller/annotator_controller.py
+++ b/napari_allencell_annotator/controller/annotator_controller.py
@@ -72,7 +72,7 @@ class AnnotatorController:
         self.view.cancel_btn.clicked.connect(self.stop_viewing)
         # we want to save the annotation for the image that we just switched off of.
         self._annotation_model.image_changed.connect(
-            lambda: self.record_annotations(self._annotation_model.get_previous_image_index())
+            lambda: self._record_annotations(self._annotation_model.get_previous_image_index())
         )
 
     def write_json(self, file_path: str):
@@ -119,13 +119,13 @@ class AnnotatorController:
     def save_annotations(self):
         """Save current annotation data"""
         # save annotations for file we're on
-        self.record_annotations(self._annotation_model.get_curr_img_index())
+        self._record_annotations(self._annotation_model.get_curr_img_index())
         self.write_csv()
 
     def stop_annotating(self):
         """Reset values from annotating and change mode to ADD."""
         # TODO: DO WE WANT TO SAVE ALL IMAGES WITHOUT ANNOTATIONS
-        self.record_annotations(self._annotation_model.get_curr_img_index())
+        self._record_annotations(self._annotation_model.get_curr_img_index())
 
         # Save rest of annotations, even if empty
         for idx in range(self._annotation_model.get_num_images()):
@@ -195,7 +195,7 @@ class AnnotatorController:
             else:
                 self.view.prev_btn.setEnabled(True)
 
-    def record_annotations(self, record_idx: int):
+    def _record_annotations(self, record_idx: int):
         """
         Add the image's annotation values to the annotation dictionary
 

--- a/napari_allencell_annotator/controller/annotator_controller.py
+++ b/napari_allencell_annotator/controller/annotator_controller.py
@@ -113,7 +113,6 @@ class AnnotatorController:
         """
         self.view.set_mode(mode=AnnotatorViewMode.ANNOTATE)
 
-        # self.view.annot_list.create_evt_listeners()
         # self.view.annot_list.currentItemChanged.connect(self._curr_item_changed)
 
     def save_annotations(self):

--- a/napari_allencell_annotator/controller/annotator_controller.py
+++ b/napari_allencell_annotator/controller/annotator_controller.py
@@ -212,6 +212,7 @@ class AnnotatorController:
                 self._annotation_model.get_all_images()[record_idx], self.view.get_curr_annots()
             )
             self._annotation_model.clear_all_cur_img_points_layers()
+            self._annotation_model.annotation_saved()
 
     def read_json(self, file_path: Path):
         # TODO change param to path

--- a/napari_allencell_annotator/controller/annotator_controller.py
+++ b/napari_allencell_annotator/controller/annotator_controller.py
@@ -135,6 +135,7 @@ class AnnotatorController:
         self.write_csv()
         # reset optional fields in model to None (pre-annottion state)
         self._annotation_model.set_annotation_started(False)
+        self.view.viewer.set_all_points_layer_to_pan_zoom(None)
         self._annotation_model.set_csv_save_path(None)
         self.view.set_mode(AnnotatorViewMode.VIEW)
 
@@ -211,8 +212,10 @@ class AnnotatorController:
             self._annotation_model.add_annotation(
                 self._annotation_model.get_all_images()[record_idx], self.view.get_curr_annots()
             )
-            self._annotation_model.clear_all_cur_img_points_layers()
-        self._annotation_model.annotation_saved()
+            self.view.annot_list.setCurrentItem(None)
+            # self._annotation_model.clear_all_cur_img_points_layers()
+        if record_idx == self._annotation_model.get_previous_image_index():
+            self._annotation_model.annotation_saved()
 
     def read_json(self, file_path: Path):
         # TODO change param to path

--- a/napari_allencell_annotator/controller/annotator_controller.py
+++ b/napari_allencell_annotator/controller/annotator_controller.py
@@ -135,7 +135,7 @@ class AnnotatorController:
         self.write_csv()
         # reset optional fields in model to None (pre-annottion state)
         self._annotation_model.set_annotation_started(False)
-        self.view.viewer.set_all_points_layer_to_pan_zoom(None)
+        self.view.viewer.set_all_points_layer_to_pan_zoom()
         self._annotation_model.set_csv_save_path(None)
         self.view.set_mode(AnnotatorViewMode.VIEW)
 
@@ -212,10 +212,11 @@ class AnnotatorController:
             self._annotation_model.add_annotation(
                 self._annotation_model.get_all_images()[record_idx], self.view.get_curr_annots()
             )
-            self.view.annot_list.setCurrentItem(None)
             # self._annotation_model.clear_all_cur_img_points_layers()
         if record_idx == self._annotation_model.get_previous_image_index():
             self._annotation_model.annotation_saved()
+
+        self.view.annot_list.setCurrentItem(None)
 
     def read_json(self, file_path: Path):
         # TODO change param to path

--- a/napari_allencell_annotator/controller/annotator_controller.py
+++ b/napari_allencell_annotator/controller/annotator_controller.py
@@ -194,7 +194,7 @@ class AnnotatorController:
             else:
                 self.view.prev_btn.setEnabled(True)
 
-    def _record_annotations(self, record_idx: int):
+    def _record_annotations(self, record_idx: int) -> None:
         """
         Add the image's annotation values to the annotation dictionary
 

--- a/napari_allencell_annotator/controller/annotator_controller.py
+++ b/napari_allencell_annotator/controller/annotator_controller.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+from napari_allencell_annotator.view.i_viewer import IViewer
+
 from napari_allencell_annotator.model.annotation_model import AnnotatorModel
 from napari_allencell_annotator.model.key import Key
 from napari_allencell_annotator.util.file_utils import FileUtils
@@ -59,7 +61,7 @@ class AnnotatorController:
         Writes header and annotations to the csv file.
     """
 
-    def __init__(self, model: AnnotatorModel, viewer: napari.Viewer):
+    def __init__(self, model: AnnotatorModel, viewer: IViewer):
         self._annotation_model = model
 
         # open in view mode

--- a/napari_allencell_annotator/controller/annotator_controller.py
+++ b/napari_allencell_annotator/controller/annotator_controller.py
@@ -212,7 +212,7 @@ class AnnotatorController:
                 self._annotation_model.get_all_images()[record_idx], self.view.get_curr_annots()
             )
             self._annotation_model.clear_all_cur_img_points_layers()
-            self._annotation_model.annotation_saved()
+        self._annotation_model.annotation_saved()
 
     def read_json(self, file_path: Path):
         # TODO change param to path

--- a/napari_allencell_annotator/controller/annotator_controller.py
+++ b/napari_allencell_annotator/controller/annotator_controller.py
@@ -113,7 +113,7 @@ class AnnotatorController:
         """
         self.view.set_mode(mode=AnnotatorViewMode.ANNOTATE)
 
-        self.view.annot_list.create_evt_listeners()
+        # self.view.annot_list.create_evt_listeners()
         # self.view.annot_list.currentItemChanged.connect(self._curr_item_changed)
 
     def save_annotations(self):

--- a/napari_allencell_annotator/model/annotation_model.py
+++ b/napari_allencell_annotator/model/annotation_model.py
@@ -175,11 +175,11 @@ class AnnotatorModel(QObject):
     def get_points_layer(self, name: str) -> Points:
         return self._curr_img_points_layer[name]
 
-    def edit_points_layer(self, annot_name: str):
+    def edit_points_layer(self, annot_name: str) -> None:
         self.edit_points_layer_changed.emit(annot_name)
 
-    def annotation_saved(self):
+    def annotation_saved(self) -> None:
         self.annotation_recorded.emit()
 
-    def change_current_annot_item(self):
+    def change_current_annot_item(self) -> None:
         self.current_annot_changed.emit()

--- a/napari_allencell_annotator/model/annotation_model.py
+++ b/napari_allencell_annotator/model/annotation_model.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from typing import Optional, Any
 
 from PyQt5.QtCore import QObject
+from napari.layers import Points
 from qtpy.QtCore import Signal
 
 from napari_allencell_annotator.model.key import Key
@@ -40,6 +41,9 @@ class AnnotatorModel(QObject):
         self._csv_save_path: Optional[Path] = None
 
         self._annotation_started = False
+
+        # dict storing current point layers {name: PointsLayer}
+        self._curr_img_points_layer: dict[str, Points] = {}
 
     def get_annotation_keys(self) -> dict[str, Key]:
         return self._annotation_keys
@@ -154,3 +158,9 @@ class AnnotatorModel(QObject):
     def set_annotation_started(self, started: bool) -> None:
         self._annotation_started = started
         self.annotation_started_changed.emit(started)
+
+    def get_all_curr_img_points_layers(self) -> dict[str, Points]:
+        return self._curr_img_points_layer
+
+    def set_points_layer(self, name: str, points_layer: Points):
+        self._curr_img_points_layer[name] = points_layer

--- a/napari_allencell_annotator/model/annotation_model.py
+++ b/napari_allencell_annotator/model/annotation_model.py
@@ -163,6 +163,9 @@ class AnnotatorModel(QObject):
     def get_all_curr_img_points_layers(self) -> dict[str, Points]:
         return self._curr_img_points_layer
 
+    def clear_all_cur_img_points_layers(self) -> None:
+        self._curr_img_points_layer = {}
+
     def add_points_layer(self, name: str, points_layer: Points):
         self._curr_img_points_layer[name] = points_layer
 

--- a/napari_allencell_annotator/model/annotation_model.py
+++ b/napari_allencell_annotator/model/annotation_model.py
@@ -17,6 +17,7 @@ class AnnotatorModel(QObject):
     annotation_started_changed: Signal = Signal()
     edit_points_layer_changed: Signal = Signal(str)
     annotation_recorded: Signal = Signal()
+    current_annot_changed: Signal = Signal()
 
     def __init__(self):
         super().__init__()
@@ -122,6 +123,7 @@ class AnnotatorModel(QObject):
 
     def set_curr_img_index(self, idx: int) -> None:
         self._curr_img_index = idx
+        self.clear_all_cur_img_points_layers()
         self.image_changed.emit()
 
     def get_curr_img(self) -> Optional[Path]:
@@ -178,3 +180,6 @@ class AnnotatorModel(QObject):
 
     def annotation_saved(self):
         self.annotation_recorded.emit()
+
+    def change_current_annot_item(self):
+        self.current_annot_changed.emit()

--- a/napari_allencell_annotator/model/annotation_model.py
+++ b/napari_allencell_annotator/model/annotation_model.py
@@ -13,6 +13,7 @@ class AnnotatorModel(QObject):
     image_count_changed: Signal = Signal(int)
     images_shuffled: Signal = Signal(bool)
     image_set_added: Signal = Signal()
+    annotation_started_changed: Signal = Signal(bool)
 
     def __init__(self):
         super().__init__()
@@ -152,3 +153,4 @@ class AnnotatorModel(QObject):
 
     def set_annotation_started(self, started: bool) -> None:
         self._annotation_started = started
+        self.annotation_started_changed.emit(started)

--- a/napari_allencell_annotator/model/annotation_model.py
+++ b/napari_allencell_annotator/model/annotation_model.py
@@ -164,3 +164,6 @@ class AnnotatorModel(QObject):
 
     def set_points_layer(self, name: str, points_layer: Points):
         self._curr_img_points_layer[name] = points_layer
+
+    def get_points_layer(self, name: str) -> Points:
+        return self._curr_img_points_layer[name]

--- a/napari_allencell_annotator/model/annotation_model.py
+++ b/napari_allencell_annotator/model/annotation_model.py
@@ -14,7 +14,8 @@ class AnnotatorModel(QObject):
     image_count_changed: Signal = Signal(int)
     images_shuffled: Signal = Signal(bool)
     image_set_added: Signal = Signal()
-    annotation_started_changed: Signal = Signal(bool)
+    annotation_started_changed: Signal = Signal()
+    edit_points_layer_changed: Signal = Signal(str)
 
     def __init__(self):
         super().__init__()
@@ -157,7 +158,7 @@ class AnnotatorModel(QObject):
 
     def set_annotation_started(self, started: bool) -> None:
         self._annotation_started = started
-        self.annotation_started_changed.emit(started)
+        self.annotation_started_changed.emit()
 
     def get_all_curr_img_points_layers(self) -> dict[str, Points]:
         return self._curr_img_points_layer
@@ -167,3 +168,6 @@ class AnnotatorModel(QObject):
 
     def get_points_layer(self, name: str) -> Points:
         return self._curr_img_points_layer[name]
+
+    def edit_points_layer(self, annot_name: str):
+        self.edit_points_layer_changed.emit(annot_name)

--- a/napari_allencell_annotator/model/annotation_model.py
+++ b/napari_allencell_annotator/model/annotation_model.py
@@ -17,7 +17,6 @@ class AnnotatorModel(QObject):
     annotation_started_changed: Signal = Signal()
     edit_points_layer_changed: Signal = Signal(str)
     annotation_recorded: Signal = Signal()
-    current_annot_changed: Signal = Signal()
 
     def __init__(self):
         super().__init__()
@@ -180,6 +179,3 @@ class AnnotatorModel(QObject):
 
     def annotation_saved(self) -> None:
         self.annotation_recorded.emit()
-
-    def change_current_annot_item(self) -> None:
-        self.current_annot_changed.emit()

--- a/napari_allencell_annotator/model/annotation_model.py
+++ b/napari_allencell_annotator/model/annotation_model.py
@@ -162,7 +162,7 @@ class AnnotatorModel(QObject):
     def get_all_curr_img_points_layers(self) -> dict[str, Points]:
         return self._curr_img_points_layer
 
-    def set_points_layer(self, name: str, points_layer: Points):
+    def add_points_layer(self, name: str, points_layer: Points):
         self._curr_img_points_layer[name] = points_layer
 
     def get_points_layer(self, name: str) -> Points:

--- a/napari_allencell_annotator/model/annotation_model.py
+++ b/napari_allencell_annotator/model/annotation_model.py
@@ -16,6 +16,7 @@ class AnnotatorModel(QObject):
     image_set_added: Signal = Signal()
     annotation_started_changed: Signal = Signal()
     edit_points_layer_changed: Signal = Signal(str)
+    annotation_recorded: Signal = Signal()
 
     def __init__(self):
         super().__init__()
@@ -174,3 +175,6 @@ class AnnotatorModel(QObject):
 
     def edit_points_layer(self, annot_name: str):
         self.edit_points_layer_changed.emit(annot_name)
+
+    def annotation_saved(self):
+        self.annotation_recorded.emit()

--- a/napari_allencell_annotator/view/annotator_view.py
+++ b/napari_allencell_annotator/view/annotator_view.py
@@ -198,6 +198,7 @@ class AnnotatorView(QFrame):
     def _handle_image_changed(self):
         if self._annotator_model.get_curr_img_index() == -1:
             self.render_default_values()
+        self.annot_list.setCurrentItem(None)
 
     def display_current_progress(self):
         """

--- a/napari_allencell_annotator/view/annotator_view.py
+++ b/napari_allencell_annotator/view/annotator_view.py
@@ -244,7 +244,9 @@ class AnnotatorView(QFrame):
             else:
                 if item.type == ItemType.POINT:
                     annot_name = item.name.text()
-                    self._annotator_model.add_points_layer(annot_name, self.viewer.create_points_layer(annot_name, True, item_data))
+                    self._annotator_model.add_points_layer(
+                        annot_name, self.viewer.create_points_layer(annot_name, True, item_data)
+                    )
                 else:
                     item.set_value(item_data)
 
@@ -330,4 +332,3 @@ class AnnotatorView(QFrame):
         # for items other than points
         if self.annot_list.currentItem() is None or self.annot_list.currentItem().type != ItemType.POINT:
             self.viewer.set_all_points_layer_to_pan_zoom()
-

--- a/napari_allencell_annotator/view/annotator_view.py
+++ b/napari_allencell_annotator/view/annotator_view.py
@@ -309,4 +309,5 @@ class AnnotatorView(QFrame):
                 annot_item.name, self.viewer.create_points_layer(annot_item.name, "blue", True)
             )
 
-        # if self.viewer.set
+        annot_points_layer: Point = self._annotator_model.get_points_layer()
+        if self.viewer.get_points_layer_mode()

--- a/napari_allencell_annotator/view/annotator_view.py
+++ b/napari_allencell_annotator/view/annotator_view.py
@@ -329,6 +329,7 @@ class AnnotatorView(QFrame):
         self.viewer.toggle_points_layer(annot_points_layer)
 
     def _handle_item_changed(self):
+        # for items other than points
         if self.annot_list.currentItem() is None or self.annot_list.currentItem().type != ItemType.POINT:
             self.viewer.set_all_points_layer_to_pan_zoom()
 

--- a/napari_allencell_annotator/view/annotator_view.py
+++ b/napari_allencell_annotator/view/annotator_view.py
@@ -228,7 +228,7 @@ class AnnotatorView(QFrame):
         # TODO why do we need this?
         # self.annot_list.setCurrentItem(self.annot_list.items[0])
 
-    def render_values(self, vals: list[Any]):
+    def render_values(self, vals: list[Any]) -> None:
         """
         Set the values of the annotation widgets.
 
@@ -238,17 +238,16 @@ class AnnotatorView(QFrame):
             the values for the annotations.
         """
         for item, annotation in zip(self.annot_list.items, vals):
-            item_data = annotation
-            if item_data is None or item_data == "":
+            if annotation is None or annotation == "":
                 item.set_default_value()
             else:
                 if item.type == ItemType.POINT:
-                    annot_name = item.name.text()
+                    annot_name: str = item.name.text()
                     self._annotator_model.add_points_layer(
-                        annot_name, self.viewer.create_points_layer(annot_name, True, item_data)
+                        annot_name, self.viewer.create_points_layer(annot_name, True, annotation)
                     )
                 else:
-                    item.set_value(item_data)
+                    item.set_value(annotation)
 
         # self.annot_list.setCurrentItem(self.annot_list.items[0])
 
@@ -262,11 +261,11 @@ class AnnotatorView(QFrame):
             a list of annotation values.
         """
         annots = []
-        point_annots = self.viewer.get_all_point_annotations()
+        point_annots: dict[str, list[tuple[int]]] = self.viewer.get_all_point_annotations()
 
         for item in self.annot_list.items:
             if item.type == ItemType.POINT:
-                annot_name = item.name.text()
+                annot_name: str = item.name.text()
                 if annot_name in point_annots:
                     annots.append(point_annots[annot_name])
                 else:
@@ -321,14 +320,14 @@ class AnnotatorView(QFrame):
         self.annots_order.append(name)
         self.annot_list.add_item(name, key)
 
-    def _handle_point_selection(self, annot_name: str):
+    def _handle_point_selection(self, annot_name: str) -> None:
         if annot_name not in self._annotator_model.get_all_curr_img_points_layers():
             self._annotator_model.add_points_layer(annot_name, self.viewer.create_points_layer(annot_name, True))
 
         annot_points_layer: Points = self._annotator_model.get_points_layer(annot_name)
         self.viewer.toggle_points_layer(annot_points_layer)
 
-    def _handle_item_changed(self):
+    def _handle_item_changed(self) -> None:
         # for items other than points
         if self.annot_list.currentItem() is None or self.annot_list.currentItem().type != ItemType.POINT:
             self.viewer.set_all_points_layer_to_pan_zoom()

--- a/napari_allencell_annotator/view/annotator_view.py
+++ b/napari_allencell_annotator/view/annotator_view.py
@@ -20,6 +20,7 @@ from napari_allencell_annotator.widgets.file_input import (
     FileInput,
     FileInputMode,
 )
+from napari_allencell_annotator.widgets.template_item import ItemType, TemplateItem
 from napari_allencell_annotator.widgets.template_list import TemplateList
 from napari_allencell_annotator._style import Style
 
@@ -295,4 +296,8 @@ class AnnotatorView(QFrame):
             annotation type, default, and options.
         """
         self.annots_order.append(name)
-        self.annot_list.add_item(name, key)
+        annot_item: TemplateItem = self.annot_list.add_item(name, key)
+
+        if key.get_type() == ItemType.POINT.value:
+            self._annotator_model.annotation_started_changed.connect(annot_item.editable_widget.setEnabled)
+

--- a/napari_allencell_annotator/view/annotator_view.py
+++ b/napari_allencell_annotator/view/annotator_view.py
@@ -90,6 +90,7 @@ class AnnotatorView(QFrame):
         super().__init__()
         self._annotator_model = model
         self._annotator_model.image_changed.connect(self._handle_image_changed)
+        self._annotator_model.edit_points_layer_changed.connect(self._handle_point_selection)
         self._mode = mode
         label = QLabel("Annotations")
         label.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
@@ -299,22 +300,13 @@ class AnnotatorView(QFrame):
             annotation type, default, and options.
         """
         self.annots_order.append(name)
-        item = self.annot_list.add_item(name, key)
+        self.annot_list.add_item(name, key)
 
-        if item.type == ItemType.POINT:
-            self.annot_list.point_select_clicked.connect(self._handle_point_selection)
-
-    def _handle_point_selection(self, annot_item: TemplateItem):
-        annot_name = annot_item.name.text()
+    def _handle_point_selection(self, annot_name: str):
         if annot_name not in self._annotator_model.get_all_curr_img_points_layers():
             self._annotator_model.add_points_layer(
                 annot_name, self.viewer.create_points_layer(annot_name, "blue", True)
             )
 
         annot_points_layer: Points = self._annotator_model.get_points_layer(annot_name)
-        if self.viewer.get_points_layer_mode(annot_points_layer) == PointsLayerMode.PAN_ZOOM.value:
-            self.viewer.set_points_layer_mode(annot_points_layer, PointsLayerMode.ADD)
-            annot_item.editable_widget.setText("Finish")
-        else:
-            self.viewer.set_points_layer_mode(annot_points_layer, PointsLayerMode.PAN_ZOOM)
-            annot_item.editable_widget.setText("Select")
+        self.viewer.edit_points_layer(annot_points_layer)

--- a/napari_allencell_annotator/view/annotator_view.py
+++ b/napari_allencell_annotator/view/annotator_view.py
@@ -281,8 +281,6 @@ class AnnotatorView(QFrame):
         if self._mode == AnnotatorViewMode.ADD:
             self.add_widget.show()
             self.layout.addWidget(self.add_widget)
-            self.annot_list.setCurrentItem(None)
-            self.viewer.set_all_points_layer_to_pan_zoom()
         elif self._mode == AnnotatorViewMode.VIEW:
             self.save_json_btn.setEnabled(True)
             self.view_widget.show()

--- a/napari_allencell_annotator/view/annotator_view.py
+++ b/napari_allencell_annotator/view/annotator_view.py
@@ -282,7 +282,7 @@ class AnnotatorView(QFrame):
             self.add_widget.show()
             self.layout.addWidget(self.add_widget)
             self.annot_list.setCurrentItem(None)
-            self.viewer.set_all_points_layer_to_pan_zoom(None)
+            self.viewer.set_all_points_layer_to_pan_zoom()
         elif self._mode == AnnotatorViewMode.VIEW:
             self.save_json_btn.setEnabled(True)
             self.view_widget.show()
@@ -329,7 +329,6 @@ class AnnotatorView(QFrame):
         self.viewer.toggle_points_layer(annot_points_layer)
 
     def _handle_item_changed(self):
-        if self.annot_list.currentItem() is not None:
-            self.viewer.set_all_points_layer_to_pan_zoom(self.annot_list.currentItem().name.text())
-        else:
-            self.viewer.set_all_points_layer_to_pan_zoom(None)
+        if self.annot_list.currentItem() is None or self.annot_list.currentItem().type != ItemType.POINT:
+            self.viewer.set_all_points_layer_to_pan_zoom()
+

--- a/napari_allencell_annotator/view/annotator_view.py
+++ b/napari_allencell_annotator/view/annotator_view.py
@@ -91,6 +91,7 @@ class AnnotatorView(QFrame):
         self._annotator_model = model
         self._annotator_model.image_changed.connect(self._handle_image_changed)
         self._annotator_model.edit_points_layer_changed.connect(self._handle_point_selection)
+        self._annotator_model.current_annot_changed.connect(self._handle_item_changed)
         self._mode = mode
         label = QLabel("Annotations")
         label.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
@@ -117,6 +118,8 @@ class AnnotatorView(QFrame):
         self.layout.addWidget(self.scroll)
 
         self.curr_index: int = None
+
+        self.viewer: IViewer = viewer
 
         # Add widget visible in ADD mode
         self.add_widget = QWidget()
@@ -178,7 +181,6 @@ class AnnotatorView(QFrame):
 
         self.annots_order: List[str] = []
         self.setLayout(self.layout)
-        self.viewer: IViewer = viewer
 
     @property
     def mode(self) -> AnnotatorViewMode:
@@ -279,6 +281,8 @@ class AnnotatorView(QFrame):
         if self._mode == AnnotatorViewMode.ADD:
             self.add_widget.show()
             self.layout.addWidget(self.add_widget)
+            self.annot_list.setCurrentItem(None)
+            self.viewer.set_all_points_layer_to_pan_zoom(None)
         elif self._mode == AnnotatorViewMode.VIEW:
             self.save_json_btn.setEnabled(True)
             self.view_widget.show()
@@ -323,3 +327,9 @@ class AnnotatorView(QFrame):
 
         annot_points_layer: Points = self._annotator_model.get_points_layer(annot_name)
         self.viewer.toggle_points_layer(annot_points_layer)
+
+    def _handle_item_changed(self):
+        if self.annot_list.currentItem() is not None:
+            self.viewer.set_all_points_layer_to_pan_zoom(self.annot_list.currentItem().name.text())
+        else:
+            self.viewer.set_all_points_layer_to_pan_zoom(None)

--- a/napari_allencell_annotator/view/annotator_view.py
+++ b/napari_allencell_annotator/view/annotator_view.py
@@ -308,4 +308,5 @@ class AnnotatorView(QFrame):
             self._annotator_model.set_points_layer(
                 annot_item.name, self.viewer.create_points_layer(annot_item.name, "blue", True)
             )
-        pass
+
+        # if self.viewer.set

--- a/napari_allencell_annotator/view/annotator_view.py
+++ b/napari_allencell_annotator/view/annotator_view.py
@@ -268,14 +268,21 @@ class AnnotatorView(QFrame):
         point_annots: dict[str, list[tuple[int]]] = self.viewer.get_all_point_annotations()
 
         for item in self.annot_list.items:
-            if item.type == ItemType.POINT:
-                annot_name: str = item.name.text()
-                if annot_name in point_annots:
-                    annots.append(point_annots[annot_name])
-                else:
-                    annots.append(None)
-            else:
+            annot_name: str = item.name.text()
+
+            # if the item is not a point annotation, append the annotation from its widget to the annotation list.
+            if item.type != ItemType.POINT:
                 annots.append(item.get_value())
+
+            # if the item is a point annotation and has already been annotated, add the point coordinates to
+            # the annotation list.
+            elif annot_name in point_annots:
+                annots.append(point_annots[annot_name])
+
+            # if the item is a point annotation but has not been annotated, add None to the annotation list.
+            else:
+                annots.append(None)
+
         return annots
 
     def _display_mode(self):

--- a/napari_allencell_annotator/view/annotator_view.py
+++ b/napari_allencell_annotator/view/annotator_view.py
@@ -305,7 +305,7 @@ class AnnotatorView(QFrame):
     def _handle_point_selection(self, annot_name: str):
         if annot_name not in self._annotator_model.get_all_curr_img_points_layers():
             self._annotator_model.add_points_layer(
-                annot_name, self.viewer.create_points_layer(annot_name, "blue", True)
+                annot_name, self.viewer.create_points_layer(annot_name, True)
             )
 
         annot_points_layer: Points = self._annotator_model.get_points_layer(annot_name)

--- a/napari_allencell_annotator/view/annotator_view.py
+++ b/napari_allencell_annotator/view/annotator_view.py
@@ -1,6 +1,7 @@
 from enum import Enum
 from typing import Dict, List, Any
 
+from napari_allencell_annotator.view.i_viewer import IViewer
 from qtpy.QtWidgets import QFrame
 from qtpy import QtCore
 from qtpy.QtWidgets import (
@@ -81,7 +82,7 @@ class AnnotatorView(QFrame):
     def __init__(
         self,
         model: AnnotatorModel,
-        viewer: Viewer,
+        viewer: IViewer,
         mode: AnnotatorViewMode = AnnotatorViewMode.ADD,
     ):
         super().__init__()
@@ -174,7 +175,7 @@ class AnnotatorView(QFrame):
 
         self.annots_order: List[str] = []
         self.setLayout(self.layout)
-        self.viewer: Viewer = viewer
+        self.viewer: IViewer = viewer
 
     @property
     def mode(self) -> AnnotatorViewMode:
@@ -300,4 +301,11 @@ class AnnotatorView(QFrame):
 
         if key.get_type() == ItemType.POINT.value:
             self._annotator_model.annotation_started_changed.connect(annot_item.editable_widget.setEnabled)
+            annot_item.editable_widget.clicked.connect(self._handle_point_selection)
 
+    def _handle_point_selection(self, annot_item: TemplateItem):
+        if annot_item.name not in self._annotator_model.get_all_curr_img_points_layers():
+            self._annotator_model.set_points_layer(
+                annot_item.name, self.viewer.create_points_layer(annot_item.name, "blue", True)
+            )
+        pass

--- a/napari_allencell_annotator/view/annotator_view.py
+++ b/napari_allencell_annotator/view/annotator_view.py
@@ -304,9 +304,7 @@ class AnnotatorView(QFrame):
 
     def _handle_point_selection(self, annot_name: str):
         if annot_name not in self._annotator_model.get_all_curr_img_points_layers():
-            self._annotator_model.add_points_layer(
-                annot_name, self.viewer.create_points_layer(annot_name, True)
-            )
+            self._annotator_model.add_points_layer(annot_name, self.viewer.create_points_layer(annot_name, True))
 
         annot_points_layer: Points = self._annotator_model.get_points_layer(annot_name)
         self.viewer.toggle_points_layer(annot_points_layer)

--- a/napari_allencell_annotator/view/annotator_view.py
+++ b/napari_allencell_annotator/view/annotator_view.py
@@ -257,13 +257,13 @@ class AnnotatorView(QFrame):
             a list of annotation values.
         """
         annots = []
-        # point_annots = self.viewer.get_all_point_annotations()
+        point_annots = self.viewer.get_all_point_annotations()
 
         for item in self.annot_list.items:
             if item.type == ItemType.POINT:
                 annot_name = item.name.text()
-                if annot_name in self._annotator_model.get_all_curr_img_points_layers():
-                    annots.append(self.viewer.get_selected_points(self._annotator_model.get_points_layer(annot_name)))
+                if annot_name in point_annots:
+                    annots.append(point_annots[annot_name])
                 else:
                     annots.append(None)
             else:

--- a/napari_allencell_annotator/view/annotator_view.py
+++ b/napari_allencell_annotator/view/annotator_view.py
@@ -91,7 +91,6 @@ class AnnotatorView(QFrame):
         self._annotator_model = model
         self._annotator_model.image_changed.connect(self._handle_image_changed)
         self._annotator_model.edit_points_layer_changed.connect(self._handle_point_selection)
-        self._annotator_model.current_annot_changed.connect(self._handle_item_changed)
         self._mode = mode
         label = QLabel("Annotations")
         label.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
@@ -99,6 +98,7 @@ class AnnotatorView(QFrame):
         self.layout.addWidget(label)
         self.setStyleSheet(Style.get_stylesheet("main.qss"))
         self.annot_list = TemplateList(model)
+        self.annot_list.currentItemChanged.connect(self._handle_item_changed)
         self.scroll = QScrollArea()
         self.scroll.setWidget(self.annot_list)
         self.scroll.setWidgetResizable(True)

--- a/napari_allencell_annotator/view/annotator_view.py
+++ b/napari_allencell_annotator/view/annotator_view.py
@@ -238,16 +238,20 @@ class AnnotatorView(QFrame):
             the values for the annotations.
         """
         for item, annotation in zip(self.annot_list.items, vals):
+            # if the item hasn't been annotated, render the default value.
             if annotation is None or annotation == "":
                 item.set_default_value()
+
+            # if the item has been annotated and is a point annotation, creates and add the points layer to the viewer.
+            elif item.type == ItemType.POINT:
+                annot_name: str = item.name.text()
+                self._annotator_model.add_points_layer(
+                    annot_name, self.viewer.create_points_layer(annot_name, True, annotation)
+                )
+
+            # if the item has been annotated but is not a point annotation, render the annotation value.
             else:
-                if item.type == ItemType.POINT:
-                    annot_name: str = item.name.text()
-                    self._annotator_model.add_points_layer(
-                        annot_name, self.viewer.create_points_layer(annot_name, True, annotation)
-                    )
-                else:
-                    item.set_value(annotation)
+                item.set_value(annotation)
 
         # self.annot_list.setCurrentItem(self.annot_list.items[0])
 

--- a/napari_allencell_annotator/view/annotator_view.py
+++ b/napari_allencell_annotator/view/annotator_view.py
@@ -97,7 +97,6 @@ class AnnotatorView(QFrame):
         self.layout.addWidget(label)
         self.setStyleSheet(Style.get_stylesheet("main.qss"))
         self.annot_list = TemplateList(model)
-        self.annot_list.point_select_clicked.connect(self._handle_point_selection)
         self.scroll = QScrollArea()
         self.scroll.setWidget(self.annot_list)
         self.scroll.setWidgetResizable(True)
@@ -300,9 +299,13 @@ class AnnotatorView(QFrame):
             annotation type, default, and options.
         """
         self.annots_order.append(name)
-        self.annot_list.add_item(name, key)
+        item = self.annot_list.add_item(name, key)
 
-    def _handle_point_selection(self, annot_name: str):
+        if item.type == ItemType.POINT:
+            self.annot_list.point_select_clicked.connect(self._handle_point_selection)
+
+    def _handle_point_selection(self, annot_item: TemplateItem):
+        annot_name = annot_item.name.text()
         if annot_name not in self._annotator_model.get_all_curr_img_points_layers():
             self._annotator_model.add_points_layer(
                 annot_name, self.viewer.create_points_layer(annot_name, "blue", True)
@@ -311,5 +314,7 @@ class AnnotatorView(QFrame):
         annot_points_layer: Points = self._annotator_model.get_points_layer(annot_name)
         if self.viewer.get_points_layer_mode(annot_points_layer) == PointsLayerMode.PAN_ZOOM.value:
             self.viewer.set_points_layer_mode(annot_points_layer, PointsLayerMode.ADD)
+            annot_item.editable_widget.setText("Finish")
         else:
             self.viewer.set_points_layer_mode(annot_points_layer, PointsLayerMode.PAN_ZOOM)
+            annot_item.editable_widget.setText("Select")

--- a/napari_allencell_annotator/view/annotator_view.py
+++ b/napari_allencell_annotator/view/annotator_view.py
@@ -241,7 +241,7 @@ class AnnotatorView(QFrame):
             else:
                 if item.type == ItemType.POINT:
                     annot_name = item.name.text()
-                    self._annotator_model.add_points_layer(annot_name, self.viewer.create_points_layer(annot_name, True))
+                    self._annotator_model.add_points_layer(annot_name, self.viewer.create_points_layer(annot_name, True, item_data))
                 else:
                     item.set_value(item_data)
 

--- a/napari_allencell_annotator/view/annotator_view.py
+++ b/napari_allencell_annotator/view/annotator_view.py
@@ -309,4 +309,4 @@ class AnnotatorView(QFrame):
             )
 
         annot_points_layer: Points = self._annotator_model.get_points_layer(annot_name)
-        self.viewer.edit_points_layer(annot_points_layer)
+        self.viewer.toggle_points_layer(annot_points_layer)

--- a/napari_allencell_annotator/view/annotator_view.py
+++ b/napari_allencell_annotator/view/annotator_view.py
@@ -239,7 +239,12 @@ class AnnotatorView(QFrame):
             if item_data is None or item_data == "":
                 item.set_default_value()
             else:
-                item.set_value(item_data)
+                if item.type == ItemType.POINT:
+                    annot_name = item.name.text()
+                    self._annotator_model.add_points_layer(annot_name, self.viewer.create_points_layer(annot_name, True))
+                else:
+                    item.set_value(item_data)
+
         # self.annot_list.setCurrentItem(self.annot_list.items[0])
 
     def get_curr_annots(self) -> List[Any]:
@@ -252,8 +257,17 @@ class AnnotatorView(QFrame):
             a list of annotation values.
         """
         annots = []
-        for i in self.annot_list.items:
-            annots.append(i.get_value())
+        # point_annots = self.viewer.get_all_point_annotations()
+
+        for item in self.annot_list.items:
+            if item.type == ItemType.POINT:
+                annot_name = item.name.text()
+                if annot_name in self._annotator_model.get_all_curr_img_points_layers():
+                    annots.append(self.viewer.get_selected_points(self._annotator_model.get_points_layer(annot_name)))
+                else:
+                    annots.append(None)
+            else:
+                annots.append(item.get_value())
         return annots
 
     def _display_mode(self):

--- a/napari_allencell_annotator/view/i_viewer.py
+++ b/napari_allencell_annotator/view/i_viewer.py
@@ -66,9 +66,9 @@ class IViewer(ABC):
         pass
 
     @abstractmethod
-    def toggle_points_layer(self, annot_points_layer: Points):
+    def toggle_points_layer(self, annot_points_layer: Points) -> None:
         pass
 
     @abstractmethod
-    def set_all_points_layer_to_pan_zoom(self):
+    def set_all_points_layer_to_pan_zoom(self) -> None:
         pass

--- a/napari_allencell_annotator/view/i_viewer.py
+++ b/napari_allencell_annotator/view/i_viewer.py
@@ -1,9 +1,23 @@
 from abc import ABC, abstractmethod
+from enum import Enum
+
 import numpy as np
 from napari.layers import Layer, Points
 from typing import List, Tuple
 
-from napari_allencell_annotator.view.viewer import PointsLayerMode
+
+class PointsLayerMode(Enum):
+    """
+    Mode for view.
+
+    ADD is used to add points.
+    SELECT is used to move, edit, or delete points.
+    PAN_ZOOM is the default mode and allows normal interactivity with the canvas.
+    """
+
+    ADD = "add"
+    SELECT = "select"
+    PAN_ZOOM = "pan_zoom"
 
 
 class IViewer(ABC):

--- a/napari_allencell_annotator/view/i_viewer.py
+++ b/napari_allencell_annotator/view/i_viewer.py
@@ -3,6 +3,8 @@ import numpy as np
 from napari.layers import Layer, Points
 from typing import List, Tuple
 
+from napari_allencell_annotator.view.viewer import PointsLayerMode
+
 
 class IViewer(ABC):
     def __init__(self):
@@ -31,6 +33,14 @@ class IViewer(ABC):
 
     @abstractmethod
     def create_points_layer(self, name: str, color: str, visible: bool, data: np.ndarray = None) -> Points:
+        pass
+
+    @abstractmethod
+    def set_points_layer_mode(self, points_layer: Points, mode: PointsLayerMode) -> None:
+        pass
+
+    @abstractmethod
+    def get_points_layer_mode(self, points_layer: Points) -> str:
         pass
 
     @abstractmethod

--- a/napari_allencell_annotator/view/i_viewer.py
+++ b/napari_allencell_annotator/view/i_viewer.py
@@ -46,7 +46,7 @@ class IViewer(ABC):
         pass
 
     @abstractmethod
-    def create_points_layer(self, name: str, color: str, visible: bool, data: np.ndarray = None) -> Points:
+    def create_points_layer(self, name: str, visible: bool, data: np.ndarray = None) -> Points:
         pass
 
     @abstractmethod

--- a/napari_allencell_annotator/view/i_viewer.py
+++ b/napari_allencell_annotator/view/i_viewer.py
@@ -64,3 +64,11 @@ class IViewer(ABC):
     @abstractmethod
     def get_all_point_annotations(self) -> dict[str, list[tuple]]:
         pass
+
+    @abstractmethod
+    def toggle_points_layer(self, annot_points_layer: Points):
+        pass
+
+    @abstractmethod
+    def set_all_points_layer_to_pan_zoom(self):
+        pass

--- a/napari_allencell_annotator/view/images_view.py
+++ b/napari_allencell_annotator/view/images_view.py
@@ -112,10 +112,15 @@ class ImagesView(QFrame):
         self.file_widget.files_selected.connect(self._toggle_delete_button_text)
 
         self._annotator_model.annotation_recorded.connect(self._display_img)
-        self._annotator_model.annotation_started_changed.connect(self._display_img)
+        self._annotator_model.annotation_started_changed.connect(self._handle_annotation_started)
         self._annotator_model.image_count_changed.connect(self._handle_image_count_changed)
         self._annotator_model.images_shuffled.connect(self._handle_shuffle_ui)
         self._annotator_model.images_shuffled.connect(self.viewer.clear_layers)
+
+    def _handle_annotation_started(self):
+        if self._annotator_model.is_annotation_started():
+            self._display_img()
+
 
     def _handle_shuffle_ui(self, checked: bool) -> None:
         """

--- a/napari_allencell_annotator/view/images_view.py
+++ b/napari_allencell_annotator/view/images_view.py
@@ -121,7 +121,6 @@ class ImagesView(QFrame):
         if self._annotator_model.is_annotation_started():
             self._display_img()
 
-
     def _handle_shuffle_ui(self, checked: bool) -> None:
         """
         Update shuffle button text to reflect toggle state.

--- a/napari_allencell_annotator/view/images_view.py
+++ b/napari_allencell_annotator/view/images_view.py
@@ -111,7 +111,8 @@ class ImagesView(QFrame):
         self.delete.clicked.connect(self._handle_delete_clicked)
         self.file_widget.files_selected.connect(self._toggle_delete_button_text)
 
-        self._annotator_model.image_changed.connect(self._display_img)
+        self._annotator_model.annotation_recorded.connect(self._display_img)
+        self._annotator_model.annotation_started_changed.connect(self._display_img)
         self._annotator_model.image_count_changed.connect(self._handle_image_count_changed)
         self._annotator_model.images_shuffled.connect(self._handle_shuffle_ui)
         self._annotator_model.images_shuffled.connect(self.viewer.clear_layers)

--- a/napari_allencell_annotator/view/images_view.py
+++ b/napari_allencell_annotator/view/images_view.py
@@ -117,7 +117,7 @@ class ImagesView(QFrame):
         self._annotator_model.images_shuffled.connect(self._handle_shuffle_ui)
         self._annotator_model.images_shuffled.connect(self.viewer.clear_layers)
 
-    def _handle_annotation_started(self):
+    def _handle_annotation_started(self) -> None:
         if self._annotator_model.is_annotation_started():
             self._display_img()
 

--- a/napari_allencell_annotator/view/images_view.py
+++ b/napari_allencell_annotator/view/images_view.py
@@ -118,6 +118,9 @@ class ImagesView(QFrame):
         self._annotator_model.images_shuffled.connect(self.viewer.clear_layers)
 
     def _handle_annotation_started(self) -> None:
+        """
+        Display the current image when annotation starts.
+        """
         if self._annotator_model.is_annotation_started():
             self._display_img()
 

--- a/napari_allencell_annotator/view/viewer.py
+++ b/napari_allencell_annotator/view/viewer.py
@@ -6,7 +6,7 @@ from napari.layers import Layer, Points
 from napari_allencell_annotator.view.i_viewer import IViewer
 from napari.utils.notifications import show_info
 import napari
-from napari.utils.colormaps import label_colormap
+from napari.utils.colormaps.standardize_color import get_color_namelist
 
 
 class PointsLayerMode(Enum):
@@ -29,6 +29,19 @@ class Viewer(IViewer):
     def __init__(self, viewer: napari.Viewer):
         super().__init__()
         self.viewer: napari.Viewer = viewer
+        self.colors: list[str] = [
+            "blue",
+            "fuchsia",
+            "green",
+            "lime",
+            "purple",
+            "red",
+            "royalblue",
+            "sandybrown",
+            "tomato",
+            "turquoise",
+            "yellow",
+        ]
 
     def add_image(self, image: np.ndarray) -> None:
         """
@@ -88,8 +101,10 @@ class Viewer(IViewer):
         Points
             A new point layer
         """
+        color: str = np.random.choice(self.colors)
+        self.colors.remove(color)
         points_layer: Points = self.viewer.add_points(
-            data=data, name=name, face_color=label_colormap(256).colors[np.random.randint(0, 256)], visible=visible, ndim=self.viewer.dims.ndim
+            data=data, name=name, face_color=color, visible=visible, ndim=self.viewer.dims.ndim
         )
         return points_layer
 
@@ -153,4 +168,3 @@ class Viewer(IViewer):
         for points_layer in self.get_all_points_layers():
             self.set_points_layer_mode(points_layer, PointsLayerMode.PAN_ZOOM)
             points_layer.selected_data = []
-

--- a/napari_allencell_annotator/view/viewer.py
+++ b/napari_allencell_annotator/view/viewer.py
@@ -139,10 +139,12 @@ class Viewer(IViewer):
 
         return all_point_annotations
 
-    def edit_points_layer(self, annot_points_layer: Points):
+    def toggle_points_layer(self, annot_points_layer: Points):
         if self.get_points_layer_mode(annot_points_layer) == PointsLayerMode.PAN_ZOOM.value:
             self.set_all_points_layer_to_pan_zoom()
             self.set_points_layer_mode(annot_points_layer, PointsLayerMode.ADD)
+            self.viewer.layers.selection.clear()
+            self.viewer.layers.selection.add(annot_points_layer)
         else:
             self.set_points_layer_mode(annot_points_layer, PointsLayerMode.PAN_ZOOM)
 

--- a/napari_allencell_annotator/view/viewer.py
+++ b/napari_allencell_annotator/view/viewer.py
@@ -108,7 +108,7 @@ class Viewer(IViewer):
         """
         points_layer.mode = mode.value
 
-    def get_points_layer_mode(self, points_layer: Points):
+    def get_points_layer_mode(self, points_layer: Points) -> str:
         return points_layer.mode
 
     def get_selected_points(self, point_layer: Points) -> list[tuple]:

--- a/napari_allencell_annotator/view/viewer.py
+++ b/napari_allencell_annotator/view/viewer.py
@@ -1,12 +1,12 @@
-from typing import List, Tuple, Dict, Optional
+from typing import List, Tuple
 from enum import Enum
 
-import dask.array
 import numpy as np
 from napari.layers import Layer, Points
 from napari_allencell_annotator.view.i_viewer import IViewer
 from napari.utils.notifications import show_info
 import napari
+from napari.utils.colormaps import label_colormap
 
 
 class PointsLayerMode(Enum):
@@ -70,7 +70,7 @@ class Viewer(IViewer):
         """
         return [layer for layer in self.get_layers() if isinstance(layer, Points)]
 
-    def create_points_layer(self, name: str, color: str, visible: bool, data: np.ndarray = None) -> Points:
+    def create_points_layer(self, name: str, visible: bool, data: np.ndarray = None) -> Points:
         """
         Creates a new point layer and sets to ADD mode to allow users to select points.
 
@@ -78,8 +78,6 @@ class Viewer(IViewer):
         ----------
         name: str
             The name of the point layer
-        color: str
-            The face color of the points
         visible: bool
             Whether the point layer is visible in the viewer
         data: np.ndarray = None
@@ -91,7 +89,7 @@ class Viewer(IViewer):
             A new point layer
         """
         points_layer: Points = self.viewer.add_points(
-            data=data, name=name, face_color=color, visible=visible, ndim=self.viewer.dims.ndim
+            data=data, name=name, face_color=label_colormap(256).colors[np.random.randint(0, 256)], visible=visible, ndim=self.viewer.dims.ndim
         )
         return points_layer
 

--- a/napari_allencell_annotator/view/viewer.py
+++ b/napari_allencell_annotator/view/viewer.py
@@ -143,6 +143,12 @@ class Viewer(IViewer):
 
     def edit_points_layer(self, annot_points_layer: Points):
         if self.get_points_layer_mode(annot_points_layer) == PointsLayerMode.PAN_ZOOM.value:
+            self.set_all_points_layer_to_pan_zoom()
             self.set_points_layer_mode(annot_points_layer, PointsLayerMode.ADD)
         else:
             self.set_points_layer_mode(annot_points_layer, PointsLayerMode.PAN_ZOOM)
+
+    def set_all_points_layer_to_pan_zoom(self):
+        for points_layer in self.get_all_points_layers():
+            self.set_points_layer_mode(points_layer, PointsLayerMode.PAN_ZOOM)
+

--- a/napari_allencell_annotator/view/viewer.py
+++ b/napari_allencell_annotator/view/viewer.py
@@ -146,9 +146,11 @@ class Viewer(IViewer):
             self.viewer.layers.selection.clear()
             self.viewer.layers.selection.add(annot_points_layer)
         else:
+            annot_points_layer.selected_data = []
             self.set_points_layer_mode(annot_points_layer, PointsLayerMode.PAN_ZOOM)
 
     def set_all_points_layer_to_pan_zoom(self):
         for points_layer in self.get_all_points_layers():
             self.set_points_layer_mode(points_layer, PointsLayerMode.PAN_ZOOM)
+            points_layer.selected_data = []
 

--- a/napari_allencell_annotator/view/viewer.py
+++ b/napari_allencell_annotator/view/viewer.py
@@ -162,13 +162,21 @@ class Viewer(IViewer):
         annot_points_layer: Points
             The target points layer
         """
+
+        # if the target points layer is in the PAN_ZOOM mode, start point annotating.
         if self.get_points_layer_mode(annot_points_layer) == PointsLayerMode.PAN_ZOOM.value:
+            # set all points layer to PAN_ZOOM
             self.set_all_points_layer_to_pan_zoom()
+            # change the target points layer to ADD
             self.set_points_layer_mode(annot_points_layer, PointsLayerMode.ADD)
+            # change the currently selected points layer to the target points layer
             self.viewer.layers.selection.clear()
             self.viewer.layers.selection.add(annot_points_layer)
+        # if the target points layer is in the ADD mode, stop point annotating.
         else:
+            # unselect the most recently added points
             annot_points_layer.selected_data = []
+            # change the target points layer to PAN_ZOOM mode
             self.set_points_layer_mode(annot_points_layer, PointsLayerMode.PAN_ZOOM)
 
     def set_all_points_layer_to_pan_zoom(self) -> None:

--- a/napari_allencell_annotator/view/viewer.py
+++ b/napari_allencell_annotator/view/viewer.py
@@ -152,7 +152,7 @@ class Viewer(IViewer):
 
         return all_point_annotations
 
-    def toggle_points_layer(self, annot_points_layer: Points):
+    def toggle_points_layer(self, annot_points_layer: Points) -> None:
         if self.get_points_layer_mode(annot_points_layer) == PointsLayerMode.PAN_ZOOM.value:
             self.set_all_points_layer_to_pan_zoom()
             self.set_points_layer_mode(annot_points_layer, PointsLayerMode.ADD)
@@ -162,7 +162,7 @@ class Viewer(IViewer):
             annot_points_layer.selected_data = []
             self.set_points_layer_mode(annot_points_layer, PointsLayerMode.PAN_ZOOM)
 
-    def set_all_points_layer_to_pan_zoom(self):
+    def set_all_points_layer_to_pan_zoom(self) -> None:
         for points_layer in self.get_all_points_layers():
             self.set_points_layer_mode(points_layer, PointsLayerMode.PAN_ZOOM)
             points_layer.selected_data = []

--- a/napari_allencell_annotator/view/viewer.py
+++ b/napari_allencell_annotator/view/viewer.py
@@ -30,17 +30,16 @@ class Viewer(IViewer):
         super().__init__()
         self.viewer: napari.Viewer = viewer
         self.colors: list[str] = [
-            "blue",
-            "fuchsia",
-            "green",
             "lime",
-            "purple",
+            "fuchsia",
             "red",
             "royalblue",
             "sandybrown",
             "tomato",
             "turquoise",
             "yellow",
+            "blue",
+            "purple",
         ]
 
     def add_image(self, image: np.ndarray) -> None:
@@ -61,17 +60,16 @@ class Viewer(IViewer):
         """
         self.viewer.layers.clear()
         self.colors: list[str] = [
-            "blue",
-            "fuchsia",
-            "green",
             "lime",
-            "purple",
+            "fuchsia",
             "red",
             "royalblue",
             "sandybrown",
             "tomato",
             "turquoise",
             "yellow",
+            "blue",
+            "purple",
         ]
 
     def alert(self, alert_msg: str) -> None:
@@ -115,7 +113,7 @@ class Viewer(IViewer):
         Points
             A new point layer
         """
-        color: str = np.random.choice(self.colors)
+        color: str = self.colors[0]
         self.colors.remove(color)
         points_layer: Points = self.viewer.add_points(
             data=data, name=name, face_color=color, visible=visible, ndim=self.viewer.dims.ndim

--- a/napari_allencell_annotator/view/viewer.py
+++ b/napari_allencell_annotator/view/viewer.py
@@ -168,7 +168,7 @@ class Viewer(IViewer):
 
     def toggle_points_layer(self, annot_points_layer: Points):
         if self.get_points_layer_mode(annot_points_layer) == PointsLayerMode.PAN_ZOOM.value:
-            self.set_all_points_layer_to_pan_zoom(annot_points_layer.name)
+            self.set_all_points_layer_to_pan_zoom()
             self.set_points_layer_mode(annot_points_layer, PointsLayerMode.ADD)
             self.viewer.layers.selection.clear()
             self.viewer.layers.selection.add(annot_points_layer)
@@ -176,8 +176,7 @@ class Viewer(IViewer):
             annot_points_layer.selected_data = []
             self.set_points_layer_mode(annot_points_layer, PointsLayerMode.PAN_ZOOM)
 
-    def set_all_points_layer_to_pan_zoom(self, current_item):
+    def set_all_points_layer_to_pan_zoom(self):
         for points_layer in self.get_all_points_layers():
-            if points_layer.name != current_item:
-                self.set_points_layer_mode(points_layer, PointsLayerMode.PAN_ZOOM)
-                points_layer.selected_data = []
+            self.set_points_layer_mode(points_layer, PointsLayerMode.PAN_ZOOM)
+            points_layer.selected_data = []

--- a/napari_allencell_annotator/view/viewer.py
+++ b/napari_allencell_annotator/view/viewer.py
@@ -108,6 +108,9 @@ class Viewer(IViewer):
         """
         points_layer.mode = mode.value
 
+    def get_points_layer_mode(self, points_layer: Points):
+        return points_layer.mode
+
     def get_selected_points(self, point_layer: Points) -> list[tuple]:
         """
         Returns a list of points in the point layer.

--- a/napari_allencell_annotator/view/viewer.py
+++ b/napari_allencell_annotator/view/viewer.py
@@ -53,7 +53,6 @@ class Viewer(IViewer):
         """
         self.viewer.add_image(image)
 
-
     def clear_layers(self) -> None:
         """
         Clear all images from the napari viewer

--- a/napari_allencell_annotator/view/viewer.py
+++ b/napari_allencell_annotator/view/viewer.py
@@ -54,11 +54,25 @@ class Viewer(IViewer):
         """
         self.viewer.add_image(image)
 
+
     def clear_layers(self) -> None:
         """
         Clear all images from the napari viewer
         """
         self.viewer.layers.clear()
+        self.colors: list[str] = [
+            "blue",
+            "fuchsia",
+            "green",
+            "lime",
+            "purple",
+            "red",
+            "royalblue",
+            "sandybrown",
+            "tomato",
+            "turquoise",
+            "yellow",
+        ]
 
     def alert(self, alert_msg: str) -> None:
         """

--- a/napari_allencell_annotator/view/viewer.py
+++ b/napari_allencell_annotator/view/viewer.py
@@ -168,7 +168,7 @@ class Viewer(IViewer):
 
     def toggle_points_layer(self, annot_points_layer: Points):
         if self.get_points_layer_mode(annot_points_layer) == PointsLayerMode.PAN_ZOOM.value:
-            self.set_all_points_layer_to_pan_zoom()
+            self.set_all_points_layer_to_pan_zoom(annot_points_layer.name)
             self.set_points_layer_mode(annot_points_layer, PointsLayerMode.ADD)
             self.viewer.layers.selection.clear()
             self.viewer.layers.selection.add(annot_points_layer)
@@ -176,7 +176,8 @@ class Viewer(IViewer):
             annot_points_layer.selected_data = []
             self.set_points_layer_mode(annot_points_layer, PointsLayerMode.PAN_ZOOM)
 
-    def set_all_points_layer_to_pan_zoom(self):
+    def set_all_points_layer_to_pan_zoom(self, current_item):
         for points_layer in self.get_all_points_layers():
-            self.set_points_layer_mode(points_layer, PointsLayerMode.PAN_ZOOM)
-            points_layer.selected_data = []
+            if points_layer.name != current_item:
+                self.set_points_layer_mode(points_layer, PointsLayerMode.PAN_ZOOM)
+                points_layer.selected_data = []

--- a/napari_allencell_annotator/view/viewer.py
+++ b/napari_allencell_annotator/view/viewer.py
@@ -153,6 +153,15 @@ class Viewer(IViewer):
         return all_point_annotations
 
     def toggle_points_layer(self, annot_points_layer: Points) -> None:
+        """
+        If the points layer mode is pan_zoom, set it to add, change other layers to pan_zoom, and select the current
+        points layer. Otherwise, unselected the latest point and set the mode to pan_zoom.
+
+        Parameters
+        ----------
+        annot_points_layer: Points
+            The target points layer
+        """
         if self.get_points_layer_mode(annot_points_layer) == PointsLayerMode.PAN_ZOOM.value:
             self.set_all_points_layer_to_pan_zoom()
             self.set_points_layer_mode(annot_points_layer, PointsLayerMode.ADD)
@@ -163,6 +172,9 @@ class Viewer(IViewer):
             self.set_points_layer_mode(annot_points_layer, PointsLayerMode.PAN_ZOOM)
 
     def set_all_points_layer_to_pan_zoom(self) -> None:
+        """
+        Sets all points layers to pan_zoom mode and unselected the selected points.
+        """
         for points_layer in self.get_all_points_layers():
             self.set_points_layer_mode(points_layer, PointsLayerMode.PAN_ZOOM)
             points_layer.selected_data = []

--- a/napari_allencell_annotator/view/viewer.py
+++ b/napari_allencell_annotator/view/viewer.py
@@ -59,18 +59,6 @@ class Viewer(IViewer):
         Clear all images from the napari viewer
         """
         self.viewer.layers.clear()
-        self.colors: list[str] = [
-            "lime",
-            "fuchsia",
-            "red",
-            "royalblue",
-            "sandybrown",
-            "tomato",
-            "turquoise",
-            "yellow",
-            "blue",
-            "purple",
-        ]
 
     def alert(self, alert_msg: str) -> None:
         """
@@ -113,8 +101,7 @@ class Viewer(IViewer):
         Points
             A new point layer
         """
-        color: str = self.colors[0]
-        self.colors.remove(color)
+        color: str = self.colors[len(self.get_all_points_layers())]
         points_layer: Points = self.viewer.add_points(
             data=data, name=name, face_color=color, visible=visible, ndim=self.viewer.dims.ndim
         )

--- a/napari_allencell_annotator/view/viewer.py
+++ b/napari_allencell_annotator/view/viewer.py
@@ -140,3 +140,9 @@ class Viewer(IViewer):
             all_point_annotations[points_layer.name] = self.get_selected_points(points_layer)
 
         return all_point_annotations
+
+    def edit_points_layer(self, annot_points_layer: Points):
+        if self.get_points_layer_mode(annot_points_layer) == PointsLayerMode.PAN_ZOOM.value:
+            self.set_points_layer_mode(annot_points_layer, PointsLayerMode.ADD)
+        else:
+            self.set_points_layer_mode(annot_points_layer, PointsLayerMode.PAN_ZOOM)

--- a/napari_allencell_annotator/widgets/template_item.py
+++ b/napari_allencell_annotator/widgets/template_item.py
@@ -127,7 +127,7 @@ class TemplateItem(QListWidgetItem):
             self.editable_widget.activated.connect(lambda: self.parent.setCurrentItem(self))
         elif self._type == ItemType.POINT:
             self.editable_widget.clicked.connect(lambda: self.parent.setCurrentItem(self))
-            self.editable_widget.clicked.connect(lambda: self._handle_select_button_clicked(self.name.text()))
+            self.editable_widget.clicked.connect(self._handle_select_button_clicked)
             self._annotation_model.annotation_started_changed.connect(self._handle_select_button_enabled)
             self._annotation_model.image_changed.connect(self._toggle_button_off)
             self.parent.currentItemChanged.connect(
@@ -144,9 +144,9 @@ class TemplateItem(QListWidgetItem):
         if self != self.parent.currentItem():
             self.editable_widget.setText("Select")
 
-    def _handle_select_button_clicked(self, annot_name):
+    def _handle_select_button_clicked(self):
         self._annotation_model.edit_points_layer(self.name.text())
-        if self.name.text() == annot_name and self.editable_widget.text() == "Select":
+        if self.editable_widget.text() == "Select":
             self.editable_widget.setText("Finish")
         else:
             self.editable_widget.setText("Select")

--- a/napari_allencell_annotator/widgets/template_item.py
+++ b/napari_allencell_annotator/widgets/template_item.py
@@ -126,8 +126,9 @@ class TemplateItem(QListWidgetItem):
             self.editable_widget.activated.connect(lambda: self.parent.setCurrentItem(self))
         elif self._type == ItemType.POINT:
             self.editable_widget.clicked.connect(lambda: self.parent.setCurrentItem(self))
-            self.editable_widget.clicked.connect(self._handle_select_button_clicked)
+            self.editable_widget.clicked.connect(lambda: self._annotation_model.edit_points_layer(self.name.text()))
             self._annotation_model.annotation_started_changed.connect(self._handle_select_button_enabled)
+            self._annotation_model.edit_points_layer_changed.connect(lambda name: self._handle_select_button_clicked(name))
 
     def _handle_select_button_enabled(self):
         if self.editable_widget.isEnabled():
@@ -135,9 +136,8 @@ class TemplateItem(QListWidgetItem):
         else:
             self.editable_widget.setEnabled(True)
 
-    def _handle_select_button_clicked(self):
-        self._annotation_model.edit_points_layer(self.name.text())
-        if self.editable_widget.text() == "Select":
+    def _handle_select_button_clicked(self, annot_name):
+        if self.name.text() == annot_name and self.editable_widget.text() == "Select":
             self.editable_widget.setText("Finish")
         else:
             self.editable_widget.setText("Select")

--- a/napari_allencell_annotator/widgets/template_item.py
+++ b/napari_allencell_annotator/widgets/template_item.py
@@ -4,7 +4,7 @@ from typing import Any
 from napari_allencell_annotator.model.annotation_model import AnnotatorModel
 from qtpy.QtWidgets import QLayout
 from qtpy.QtWidgets import QListWidgetItem, QListWidget, QWidget, QHBoxLayout, QLabel
-from qtpy.QtCore import Qt, Signal
+from qtpy.QtCore import Qt
 
 
 class ItemType(Enum):

--- a/napari_allencell_annotator/widgets/template_item.py
+++ b/napari_allencell_annotator/widgets/template_item.py
@@ -129,7 +129,6 @@ class TemplateItem(QListWidgetItem):
             self.editable_widget.clicked.connect(lambda: self.parent.setCurrentItem(self))
             self.editable_widget.clicked.connect(self._handle_select_button_clicked)
             self._annotation_model.annotation_started_changed.connect(self._handle_select_button_enabled)
-            self._annotation_model.image_changed.connect(self._toggle_button_off)
             self.parent.currentItemChanged.connect(
                 self._toggle_button_off
             )

--- a/napari_allencell_annotator/widgets/template_item.py
+++ b/napari_allencell_annotator/widgets/template_item.py
@@ -65,7 +65,7 @@ class TemplateItem(QListWidgetItem):
         self.widget.setLayout(self.layout)
         self.setSizeHint(self.widget.minimumSizeHint())
         parent.setItemWidget(self, self.widget)
-        self.create_evt_listener()
+        self._create_evt_listener()
 
     @property
     def type(self) -> ItemType:
@@ -115,7 +115,7 @@ class TemplateItem(QListWidgetItem):
         elif self._type == ItemType.LIST:
             return self.editable_widget.currentText()
 
-    def create_evt_listener(self):
+    def _create_evt_listener(self):
         """Create event listener for editable widget edits to set the current item."""
         if self._type == ItemType.STRING:
             self.editable_widget.textEdited.connect(lambda: self.parent.setCurrentItem(self))

--- a/napari_allencell_annotator/widgets/template_item.py
+++ b/napari_allencell_annotator/widgets/template_item.py
@@ -133,10 +133,7 @@ class TemplateItem(QListWidgetItem):
             )
 
     def _handle_select_button_enabled(self):
-        if self.editable_widget.isEnabled():
-            self.editable_widget.setEnabled(False)
-        else:
-            self.editable_widget.setEnabled(True)
+        self.editable_widget.setEnabled(self._annotation_model.is_annotation_started())
 
     def _handle_select_button_clicked(self, annot_name):
         if self.name.text() == annot_name and self.editable_widget.text() == "Select":

--- a/napari_allencell_annotator/widgets/template_item.py
+++ b/napari_allencell_annotator/widgets/template_item.py
@@ -129,9 +129,7 @@ class TemplateItem(QListWidgetItem):
             self.editable_widget.clicked.connect(lambda: self.parent.setCurrentItem(self))
             self.editable_widget.clicked.connect(self._handle_select_button_clicked)
             self._annotation_model.annotation_started_changed.connect(self._handle_select_button_enabled)
-            self.parent.currentItemChanged.connect(
-                self._toggle_button_off
-            )
+            self.parent.currentItemChanged.connect(self._toggle_button_off)
 
     def _handle_select_button_enabled(self):
         self.editable_widget.setEnabled(self._annotation_model.is_annotation_started())

--- a/napari_allencell_annotator/widgets/template_item.py
+++ b/napari_allencell_annotator/widgets/template_item.py
@@ -129,6 +129,7 @@ class TemplateItem(QListWidgetItem):
             self.editable_widget.clicked.connect(lambda: self.parent.setCurrentItem(self))
             self.editable_widget.clicked.connect(lambda: self._handle_select_button_clicked(self.name.text()))
             self._annotation_model.annotation_started_changed.connect(self._handle_select_button_enabled)
+            self._annotation_model.image_changed.connect(self._toggle_button_off)
             self.parent.currentItemChanged.connect(
                 self._toggle_button_off
             )

--- a/napari_allencell_annotator/widgets/template_item.py
+++ b/napari_allencell_annotator/widgets/template_item.py
@@ -137,6 +137,9 @@ class TemplateItem(QListWidgetItem):
     def _handle_select_button_enabled(self):
         self.editable_widget.setEnabled(self._annotation_model.is_annotation_started())
 
+        if not self.editable_widget.isEnabled():
+            self.editable_widget.setText("Select")
+
     def _toggle_button_off(self):
         if self != self.parent.currentItem():
             self.editable_widget.setText("Select")

--- a/napari_allencell_annotator/widgets/template_item.py
+++ b/napari_allencell_annotator/widgets/template_item.py
@@ -3,7 +3,7 @@ from typing import Any
 
 from qtpy.QtWidgets import QLayout
 from qtpy.QtWidgets import QListWidgetItem, QListWidget, QWidget, QHBoxLayout, QLabel
-from qtpy.QtCore import Qt
+from qtpy.QtCore import Qt, Signal
 
 
 class ItemType(Enum):
@@ -116,7 +116,7 @@ class TemplateItem(QListWidgetItem):
             self.editable_widget.activated.connect(lambda: self.parent.setCurrentItem(self))
         elif self._type == ItemType.POINT:
             self.editable_widget.clicked.connect(lambda: self.parent.setCurrentItem(self))
-            self.editable_widget.clicked.connect(lambda: self.parent.point_select_clicked.emit(self.name.text()))
+            self.editable_widget.clicked.connect(lambda: self.parent.point_select_clicked.emit(self))
 
     def set_focus(self):
         """Set the annotating focus on the widget of the current item."""

--- a/napari_allencell_annotator/widgets/template_item.py
+++ b/napari_allencell_annotator/widgets/template_item.py
@@ -65,6 +65,7 @@ class TemplateItem(QListWidgetItem):
         self.widget.setLayout(self.layout)
         self.setSizeHint(self.widget.minimumSizeHint())
         parent.setItemWidget(self, self.widget)
+        self.create_evt_listener()
 
     @property
     def type(self) -> ItemType:

--- a/napari_allencell_annotator/widgets/template_item.py
+++ b/napari_allencell_annotator/widgets/template_item.py
@@ -45,7 +45,7 @@ class TemplateItem(QListWidgetItem):
         self.editable_widget: QWidget = editable_widget
         self.widget = QWidget()
         self.parent = parent
-        self._annotation_model = annotator_model
+        self._annotation_model: AnnotatorModel = annotator_model
 
         self.layout = QHBoxLayout()
         self.name = QLabel(name)

--- a/napari_allencell_annotator/widgets/template_item.py
+++ b/napari_allencell_annotator/widgets/template_item.py
@@ -127,16 +127,21 @@ class TemplateItem(QListWidgetItem):
             self.editable_widget.activated.connect(lambda: self.parent.setCurrentItem(self))
         elif self._type == ItemType.POINT:
             self.editable_widget.clicked.connect(lambda: self.parent.setCurrentItem(self))
-            self.editable_widget.clicked.connect(lambda: self._annotation_model.edit_points_layer(self.name.text()))
+            self.editable_widget.clicked.connect(lambda: self._handle_select_button_clicked(self.name.text()))
             self._annotation_model.annotation_started_changed.connect(self._handle_select_button_enabled)
-            self._annotation_model.edit_points_layer_changed.connect(
-                lambda name: self._handle_select_button_clicked(name)
+            self.parent.currentItemChanged.connect(
+                self._toggle_button_off
             )
 
     def _handle_select_button_enabled(self):
         self.editable_widget.setEnabled(self._annotation_model.is_annotation_started())
 
+    def _toggle_button_off(self):
+        if self != self.parent.currentItem():
+            self.editable_widget.setText("Select")
+
     def _handle_select_button_clicked(self, annot_name):
+        self._annotation_model.edit_points_layer(self.name.text())
         if self.name.text() == annot_name and self.editable_widget.text() == "Select":
             self.editable_widget.setText("Finish")
         else:

--- a/napari_allencell_annotator/widgets/template_item.py
+++ b/napari_allencell_annotator/widgets/template_item.py
@@ -144,8 +144,7 @@ class TemplateItem(QListWidgetItem):
 
     def _toggle_button_off(self) -> None:
         """Change button texts to Select except for the current annotation item."""
-        if self != self.parent.currentItem():
-            self.editable_widget.setText("Select")
+        self.editable_widget.setText("Select")
 
     def _handle_select_button_clicked(self) -> None:
         """

--- a/napari_allencell_annotator/widgets/template_item.py
+++ b/napari_allencell_annotator/widgets/template_item.py
@@ -114,6 +114,9 @@ class TemplateItem(QListWidgetItem):
             self.editable_widget.stateChanged.connect(lambda: self.parent.setCurrentItem(self))
         elif self._type == ItemType.LIST:
             self.editable_widget.activated.connect(lambda: self.parent.setCurrentItem(self))
+        elif self._type == ItemType.POINT:
+            self.editable_widget.clicked.connect(lambda: self.parent.setCurrentItem(self))
+            self.editable_widget.clicked.connect(lambda: self.parent.point_select_clicked.emit(self.name.text()))
 
     def set_focus(self):
         """Set the annotating focus on the widget of the current item."""

--- a/napari_allencell_annotator/widgets/template_item.py
+++ b/napari_allencell_annotator/widgets/template_item.py
@@ -128,7 +128,9 @@ class TemplateItem(QListWidgetItem):
             self.editable_widget.clicked.connect(lambda: self.parent.setCurrentItem(self))
             self.editable_widget.clicked.connect(lambda: self._annotation_model.edit_points_layer(self.name.text()))
             self._annotation_model.annotation_started_changed.connect(self._handle_select_button_enabled)
-            self._annotation_model.edit_points_layer_changed.connect(lambda name: self._handle_select_button_clicked(name))
+            self._annotation_model.edit_points_layer_changed.connect(
+                lambda name: self._handle_select_button_clicked(name)
+            )
 
     def _handle_select_button_enabled(self):
         if self.editable_widget.isEnabled():

--- a/napari_allencell_annotator/widgets/template_item.py
+++ b/napari_allencell_annotator/widgets/template_item.py
@@ -136,9 +136,10 @@ class TemplateItem(QListWidgetItem):
         """
         Enable and disable the Select button when annotation starts and stops. When the button is disabled, the text is set to Select.
         """
-        self.editable_widget.setEnabled(self._annotation_model.is_annotation_started())
+        annotation_started: bool = self._annotation_model.is_annotation_started()
+        self.editable_widget.setEnabled(annotation_started)
 
-        if not self.editable_widget.isEnabled():
+        if not annotation_started:
             self.editable_widget.setText("Select")
 
     def _toggle_button_off(self) -> None:

--- a/napari_allencell_annotator/widgets/template_item.py
+++ b/napari_allencell_annotator/widgets/template_item.py
@@ -132,17 +132,24 @@ class TemplateItem(QListWidgetItem):
             self._annotation_model.annotation_started_changed.connect(self._handle_select_button_enabled)
             self.parent.currentItemChanged.connect(self._toggle_button_off)
 
-    def _handle_select_button_enabled(self):
+    def _handle_select_button_enabled(self) -> None:
+        """
+        Enable and disable the Select button when annotation starts and stops. When the button is disabled, the text is set to Select.
+        """
         self.editable_widget.setEnabled(self._annotation_model.is_annotation_started())
 
         if not self.editable_widget.isEnabled():
             self.editable_widget.setText("Select")
 
-    def _toggle_button_off(self):
+    def _toggle_button_off(self) -> None:
+        """Change button texts to Select except for the current annotation item."""
         if self != self.parent.currentItem():
             self.editable_widget.setText("Select")
 
-    def _handle_select_button_clicked(self):
+    def _handle_select_button_clicked(self) -> None:
+        """
+        Update the status of the points layer being edited in the model and toggle the button.
+        """
         self._annotation_model.edit_points_layer(self.name.text())
         if self.editable_widget.text() == "Select":
             self.editable_widget.setText("Finish")

--- a/napari_allencell_annotator/widgets/template_list.py
+++ b/napari_allencell_annotator/widgets/template_list.py
@@ -30,7 +30,6 @@ class TemplateList(QListWidget):
         self._items: List[TemplateItem] = []
         self.height: int = 0
         self.setVerticalScrollMode(QtWidgets.QAbstractItemView.ScrollPerPixel)
-        self.currentItemChanged.connect(self._annotator_model.change_current_annot_item)
 
     @property
     def items(self) -> List[TemplateItem]:

--- a/napari_allencell_annotator/widgets/template_list.py
+++ b/napari_allencell_annotator/widgets/template_list.py
@@ -24,7 +24,7 @@ class TemplateList(QListWidget):
 
     """
 
-    point_select_clicked: Signal = Signal(str)
+    point_select_clicked: Signal = Signal(TemplateItem)
 
     def __init__(self, annotator_model: AnnotatorModel):
         QListWidget.__init__(self)
@@ -127,3 +127,5 @@ class TemplateList(QListWidget):
 
         self.height = self.height + item.widget.sizeHint().height()
         self.setMaximumHeight(self.height)
+
+        return item

--- a/napari_allencell_annotator/widgets/template_list.py
+++ b/napari_allencell_annotator/widgets/template_list.py
@@ -65,7 +65,6 @@ class TemplateList(QListWidget):
             next_row = curr_row - 1
             self.setCurrentRow(next_row)
 
-
     def clear_all(self):
         """
         Clear all data.

--- a/napari_allencell_annotator/widgets/template_list.py
+++ b/napari_allencell_annotator/widgets/template_list.py
@@ -65,10 +65,6 @@ class TemplateList(QListWidget):
             next_row = curr_row - 1
             self.setCurrentRow(next_row)
 
-    def create_evt_listeners(self):
-        """Create annotating event listeners for each item."""
-        for item in self.items:
-            item.create_evt_listener()
 
     def clear_all(self):
         """

--- a/napari_allencell_annotator/widgets/template_list.py
+++ b/napari_allencell_annotator/widgets/template_list.py
@@ -1,11 +1,13 @@
 from typing import Any, List
 
-from PyQt5.QtWidgets import QPushButton
+from napari.layers import Points
 from qtpy import QtWidgets
-from qtpy.QtWidgets import QLineEdit, QCheckBox, QComboBox, QSpinBox
+from qtpy.QtWidgets import QLineEdit, QCheckBox, QComboBox, QSpinBox, QPushButton
 from qtpy.QtWidgets import QSizePolicy
 from qtpy.QtWidgets import QListWidget
+from qtpy.QtCore import Signal
 
+from napari_allencell_annotator.model.annotation_model import AnnotatorModel
 from napari_allencell_annotator.model.combo_key import ComboKey
 from napari_allencell_annotator.model.key import Key
 from napari_allencell_annotator.widgets.template_item import TemplateItem, ItemType
@@ -22,9 +24,12 @@ class TemplateList(QListWidget):
 
     """
 
-    def __init__(self):
+    point_select_clicked: Signal = Signal(str)
+
+    def __init__(self, annotator_model: AnnotatorModel):
         QListWidget.__init__(self)
 
+        self._annotator_model: AnnotatorModel = annotator_model
         self.setStyleSheet(Style.get_stylesheet("main.qss"))
         self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         # todo single selection
@@ -114,6 +119,7 @@ class TemplateList(QListWidget):
             annot_type = ItemType.POINT
             widget = QPushButton("Select")
             widget.setFixedWidth(200)
+            self._annotator_model.annotation_started_changed.connect(widget.setEnabled)
 
         item = TemplateItem(self, name, annot_type, default, widget)
 
@@ -121,5 +127,3 @@ class TemplateList(QListWidget):
 
         self.height = self.height + item.widget.sizeHint().height()
         self.setMaximumHeight(self.height)
-
-        return item

--- a/napari_allencell_annotator/widgets/template_list.py
+++ b/napari_allencell_annotator/widgets/template_list.py
@@ -24,8 +24,6 @@ class TemplateList(QListWidget):
 
     """
 
-    point_select_clicked: Signal = Signal(TemplateItem)
-
     def __init__(self, annotator_model: AnnotatorModel):
         QListWidget.__init__(self)
 
@@ -119,13 +117,10 @@ class TemplateList(QListWidget):
             annot_type = ItemType.POINT
             widget = QPushButton("Select")
             widget.setFixedWidth(200)
-            self._annotator_model.annotation_started_changed.connect(widget.setEnabled)
 
-        item = TemplateItem(self, name, annot_type, default, widget)
+        item = TemplateItem(self, name, annot_type, default, widget, self._annotator_model)
 
         self._items.append(item)
 
         self.height = self.height + item.widget.sizeHint().height()
         self.setMaximumHeight(self.height)
-
-        return item

--- a/napari_allencell_annotator/widgets/template_list.py
+++ b/napari_allencell_annotator/widgets/template_list.py
@@ -82,7 +82,7 @@ class TemplateList(QListWidget):
 
         self.height = 0
 
-    def add_item(self, name: str, key: Key | ComboKey) -> TemplateItem:
+    def add_item(self, name: str, key: Key | ComboKey):
         """
         Add annotation template item from dictionary entries.
 

--- a/napari_allencell_annotator/widgets/template_list.py
+++ b/napari_allencell_annotator/widgets/template_list.py
@@ -78,7 +78,7 @@ class TemplateList(QListWidget):
 
         self.height = 0
 
-    def add_item(self, name: str, key: Key | ComboKey):
+    def add_item(self, name: str, key: Key | ComboKey) -> TemplateItem:
         """
         Add annotation template item from dictionary entries.
 
@@ -121,3 +121,5 @@ class TemplateList(QListWidget):
 
         self.height = self.height + item.widget.sizeHint().height()
         self.setMaximumHeight(self.height)
+
+        return item

--- a/napari_allencell_annotator/widgets/template_list.py
+++ b/napari_allencell_annotator/widgets/template_list.py
@@ -34,6 +34,7 @@ class TemplateList(QListWidget):
         self._items: List[TemplateItem] = []
         self.height: int = 0
         self.setVerticalScrollMode(QtWidgets.QAbstractItemView.ScrollPerPixel)
+        self.currentItemChanged.connect(self._annotator_model.change_current_annot_item)
 
     @property
     def items(self) -> List[TemplateItem]:


### PR DESCRIPTION
<h2>Context</h2>

#83 we want to implement the UI for after annotating starts. There should be a dictionary keeping track of points layers for the current image, which gets cleared when the user changes to annotate another image. By clicking on the Select button for each layer, the user toggles the corresponding points layer to EDIT mode. The points layer will go back to PAN_ZOOM mode when the user clicks on the Finish button, annotates other fields, goes to a different image, or stops annotating. The point coordinates are saved to the annotation dictionary when the user changes to a different image, clicks the Save button, or stops annotating. The colors are different for each point layer.

<h2>Changes</h2>

1. `annotator_controller.py`

- `record_annotations()`: Calls `annotation_saved()` to emit `annotation_recorded`, which triggers the `ImagesView`object to clear all layers and display a new image, only when a new image has been selected by the user. This prevents the plugin from clearing current points layers when the user clicks Save or stops annotating. I made this method private since it is only called from within the `AnnotatorController` class.

2. `annotation_model.py`
- `annotation_started_changed` signal: When annotation starts, it triggers `_handle_annotation_started()` in `images_view.py`, which displays the current image. The signal also triggers `_handle_select_button_enabled()` in `template_item.py` to enable and disable the Select button as annotation starts and stops. It is emitted when `annotation_started` is set in `set_annotation_started()`.
- `edit_points_layer_changed` signal: This signal is emitted when the Select button is clicked. It triggers `_handle_point_selection()` in `annotation_view.py` to create a new points layer if one does not exist and call `toggle_points_layer()` in `viewer.py` to toggle the points layer.
- `annotation_recorded` signal: Emitted through annotation_saved() when annotations have been recorded to trigger displaying a new image.
- `_curr_img_points_layer` dict: Maps point annotation names to corresponding points layers. The dictionary is cleared when we change the current image through set_curr_img_index(). 
- get_all_curr_img_points_layers(), clear_all_cur_img_points_layers(), add_points_layer(), and get_points_layer() are implemented to handle operations on the _curr_img_points_layer dictionary.

3. `annotation_view.py`
- `handle_image_changed()`: set the current item in the template list to None when the user changes to a new image.
- `render_values()`: if the annotation item has not been annotated, render its default value. Otherwise, if it is a point annotation, create and render the points layer. If not, set the annotated value.
- `get_curr_annots()`: If the item is not a point annotation, get and add the value from the widget. If it is an annotated point annotation, get and add the coordinates. Otherwise, add None.
- `handle_point_selection()`: Toggle the mode of the points layer corresponding to the point annotation name. If the point annotation name is not in the point annotation dictionary, create and add a new points layer.
- `handle_item_changed()`: If the current item is set to None or not a point annotation, set all points layer to pan zoom mode.

4. `images_view.py`
- `handle_annotation_started()`: This method is subscribed to the annotation_started_changed signal. It calls `_display_img()` to display the current image when annotation starts.

5. `viewer.py`
- `create_points_layer()`: assign the color to each layer by indexing self._colors with the number of points layers instead of using the color from the method call.
- `get_points_layer_mode()`: get the current mode of the specified points layer.
- `toggle_points_layer()`: if the target points layer is in pan zoom mode, set it to add mode, set other points layers to pan zoom, and select the target points layer. It is in add mode, clear all selected points and change the mode to pan zoom.
- `set_all_points_layer_to_pan_zoom()`: set all points layers to pan zoom and clear all selected points.

6. `template_item.py`:
- `create_evt_listener()` is called when a template item is created instead of at the beginning of each annotation session. Signal connections for point annotation have been added to the if else statements.
- `handle_select_button_enabled()`: the Select button is enabled when annotation starts and disabled when annotation stops. When it is disabled, the button text is set to Select.
- `toggle_button_off()`: set the button text to Select.
- `handle_select_button_clicked()`: update the status of the point annotation in the model to allow the user to start and stop point annotating. it also changes the button text to Select and Finish.

7. `template_list.py`
- Pass `AnnotatorModel` to template items.