### PR TITLE
85 point loading from csv

### DIFF
--- a/napari_allencell_annotator/_tests/controller/test_annotator_controller.py
+++ b/napari_allencell_annotator/_tests/controller/test_annotator_controller.py
@@ -7,7 +7,6 @@ import pytest
 from pytestqt import qtbot
 
 
-
 def test_start_annotating(qtbot) -> None:
     # ARRANGE
     main_view_simulated: MainView = MainView(FakeViewer())

--- a/napari_allencell_annotator/view/main_view.py
+++ b/napari_allencell_annotator/view/main_view.py
@@ -178,8 +178,10 @@ class MainView(QFrame):
         list[any]:
             The same list of annotations with points annotations as lists of tuples
         """
+        # if that image has been annotated
         if len(annotations) > 0:
             for annotation_index, key in enumerate(self._annotator_model.get_annotation_keys().values()):
+                # if the annotation is point annotation and has been annotated, convert string to list of tuples.
                 if key.get_type() == "point" and annotations[annotation_index] != "":
                     annotations[annotation_index] = ast.literal_eval(annotations[annotation_index])
 

--- a/napari_allencell_annotator/view/main_view.py
+++ b/napari_allencell_annotator/view/main_view.py
@@ -1,3 +1,4 @@
+import ast
 import csv
 from pathlib import Path
 
@@ -149,7 +150,7 @@ class MainView(QFrame):
                     path: Path = Path(row[1])
                     image_list.append(path)
                     if use_annots:
-                        self._annotator_model.add_annotation(path, row[2:])
+                        self._annotator_model.add_annotation(path, self._process_points_annotations(row[2:]))
                     # self._images_view.add_new_item(path)
                 # start at row 0 if annotation data was not used from csv
                 file.close()
@@ -162,6 +163,14 @@ class MainView(QFrame):
                     self._annotator_model.set_shuffled_images(None)
 
             self.annots.start_viewing(use_annots)
+
+    def _process_points_annotations(self, annotations):
+        if len(annotations) > 0:
+            for annotation_index, key in enumerate(self._annotator_model.get_annotation_keys().values()):
+                if key.get_type() == "point" and annotations[annotation_index] != "":
+                    annotations[annotation_index] = ast.literal_eval(annotations[annotation_index])
+
+        return annotations
 
     def _shuffle_toggled(self, checked: bool):
         """

--- a/napari_allencell_annotator/view/main_view.py
+++ b/napari_allencell_annotator/view/main_view.py
@@ -164,7 +164,20 @@ class MainView(QFrame):
 
             self.annots.start_viewing(use_annots)
 
-    def _process_points_annotations(self, annotations):
+    def _process_points_annotations(self, annotations: list[any]) -> list[any]:
+        """
+        Convert string representations of point annotations to lists of tuples
+
+        Parameters
+        ----------
+        annotations: list[any]
+            The list of annotations read from the CSV
+
+        Returns
+        -------
+        list[any]:
+            The same list of annotations with points annotations as lists of tuples
+        """
         if len(annotations) > 0:
             for annotation_index, key in enumerate(self._annotator_model.get_annotation_keys().values()):
                 if key.get_type() == "point" and annotations[annotation_index] != "":

--- a/napari_allencell_annotator/view/main_view.py
+++ b/napari_allencell_annotator/view/main_view.py
@@ -1,4 +1,3 @@
-import ast
 import csv
 from pathlib import Path
 
@@ -183,7 +182,7 @@ class MainView(QFrame):
             for annotation_index, key in enumerate(self._annotator_model.get_annotation_keys().values()):
                 # if the annotation is point annotation and has been annotated, convert string to list of tuples.
                 if key.get_type() == "point" and annotations[annotation_index] != "":
-                    annotations[annotation_index] = ast.literal_eval(annotations[annotation_index])
+                    annotations[annotation_index] = eval(annotations[annotation_index])
 
         return annotations
 


### PR DESCRIPTION
<h2>Context</h2>
#85 This pr supports rendering point annotations from a csv file. Most of the mechanisms have already been implemented in #94, so I only added a method to convert string coordinates read from the csv to a list of tuples. 

<h2>Changes</h2>
All of the changes are in `main_view.py`

`process_points_annotations()`: This method loops through all annotations from the csv and check if each is point annotation. If it is and has been annotated, the annotation string is converted to a list of tuples.

`csv_json_import_selected_evt()`: It is modified to call `process_points_annotations()` before adding the annotations to the model.