### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Once the napari window opens, go to **Plugins**.
   - Click **Plugins** ⇨ **Annotator (napari-napari_allencell_annotator)**
 
 ## Installation from Napari Hub
-If you have previously installed Napari on your machine, you can follow these steps to install the plugin.
+If you have previously installed Napari on your machine, you can follow these steps to install the plugin from Napari Hub.
 
 ### 1. Install the Plugin
 - Open Napari

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Click the link corresponding to your OS.
 - Open a file explorer and go to the Downloads folder. Use **Option 1** below. A prompt window should open and start installing. If this fails use **Option 2**. 
   - **Option 1**: Double-click the file _install_napari.sh_
   - **Option 2**: Search the file finder for Anaconda Prompt. Open version 3. Run the following commands one line at a time. 
-    - conda create -n napari_annotator python=3.9 anaconda
+    - conda create -n napari_annotator python=3.10 anaconda
     - conda activate napari_annotator
     - python -m pip install --upgrade pip
     - python -m pip install "napari[all]"

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The plugin requires [Conda](https://docs.anaconda.com/anaconda/install/).
 
 ### 2. Install the plugin
 Click the link corresponding to your OS.
-#### [Windows](https://alleninstitute-my.sharepoint.com/:u:/g/personal/beatrice_bridge_alleninstitute_org/EVOKZ8-PZB5AvO6z6OAjZ_YB2EHbaU9XRc_Z281oM0ctOg?e=skbKzh)
+#### [Windows](https://alleninstitute-my.sharepoint.com/:u:/g/personal/r_dhamrongsirivadh_alleninstitute_org/EexXIxeeIbNEs4KMjimcXOcBMn2J2QwxJhNEkOcRHC1eVg?e=JKa5WI)
 - From the link above, click the three dots on the top menu bar and select download. 
 - Open a file explorer and go to the Downloads folder. Use **Option 1** below. A prompt window should open and start installing. If this fails use **Option 2**. 
   - **Option 1**: Double-click the file _install_napari.sh_
@@ -69,7 +69,7 @@ Click the link corresponding to your OS.
     - napari
   - **Still not working?** Try using conda forge instead of pip. 
     - Ex: conda install -c conda-forge napari instead of python -m pip install "napari[all]"
-#### [MacOS/Unix](https://alleninstitute-my.sharepoint.com/:u:/g/personal/beatrice_bridge_alleninstitute_org/EaeV_RPXZz9DijxYy7qfoeMB3Hbq4vMpmJERqDyhL97KAg?e=HuKY2k)
+#### [MacOS/Unix](https://alleninstitute-my.sharepoint.com/:u:/g/personal/r_dhamrongsirivadh_alleninstitute_org/ESeAYWwWFuRFhgpqgbiKQ6QBXdU8Dg8OU9ilpJ5VmoY-cA?e=BHpReg)
 - From the link above, download the file. 
 - Open terminal. 
 - Run _chmod +x ./Downloads/install_napari.command_ 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Click the link corresponding to your OS.
 Once the napari window opens, go to **Plugins**.
 - If **napari-allencell-annotator: Annotator** is listed click it to launch. 
 - If it is not listed 
-- **Install/Uninstall Plugins** ⇨ check the box next to **napari-allencell-annotator** ⇨ **close** ⇨ **Plugins** ⇨ **napari-allencell-annotator: Annotator** .
+- **Install/Uninstall Plugins** ⇨ check the box next to **napari-allencell-annotator** ⇨ **close** ⇨ **Plugins** ⇨ **Annotator (napari-napari_allencell_annotator)** .
 
 ### 4. Re-opening the Plugin After Installing
 - Windows
@@ -93,13 +93,13 @@ Once the napari window opens, go to **Plugins**.
   - Click on the annotator environment and wait for it to load
   - Press the play button
   - Type _napari_ in the prompt that opens
-  - Click **Plugins** ⇨ **napari-allencell-annotator: Annotator**
+  - Click **Plugins** ⇨ **Annotator (napari-napari_allencell_annotator)**
 - MacOS
   - Open terminal
   - Run these commands one line at a time
     - conda activate napari_annotator
     - napari
-  - Click **Plugins** ⇨ **napari-allencell-annotator: Annotator**
+  - Click **Plugins** ⇨ **Annotator (napari-napari_allencell_annotator)**
 
 ## Installation from Napari Hub
 If you have previously installed Napari on your machine, you can follow these steps to install the plugin.

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Click the link corresponding to your OS.
 ### 3. Launch the Plugin
 
 Once the napari window opens, go to **Plugins**.
-- If **napari-allencell-annotator: Annotator** is listed click it to launch. 
+- If **Annotator (napari-napari_allencell_annotator)** is listed click it to launch. 
 - If it is not listed 
 - **Install/Uninstall Plugins** ⇨ check the box next to **napari-allencell-annotator** ⇨ **close** ⇨ **Plugins** ⇨ **Annotator (napari-napari_allencell_annotator)** .
 

--- a/README.md
+++ b/README.md
@@ -101,9 +101,21 @@ Once the napari window opens, go to **Plugins**.
     - napari
   - Click **Plugins** ⇨ **napari-allencell-annotator: Annotator**
 
-## Installation using Command Line
-1. Open napari
-2. 
+## Installation from Napari Hub
+If you have previously installed Napari on your machine, you can follow these steps to install the plugin.
+
+### 1. Install the Plugin
+- Open Napari
+- Go to **Plugins** ⇨ **Install/Uninstall Plugins...**
+- Find **napari-allencell-annotator** in **Available Plugins**
+- Click **Install**
+- Close the window after the installation finishes
+
+### 2. Launch the Plugin
+- Click **Plugins** ⇨ **Annotator (napari-napari_allencell_annotator)**
+  - You might have to restart Napari for the annotator to appear in the plugin list.
+  - If you still can't see the plugin, go to **Install/Uninstall Plugins** ⇨ check the box next to **napari-allencell-annotator**.
+
 ## Quick Start
 
 1. Open napari

--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ Click the link corresponding to your OS.
 ### 3. Launch the Plugin
 
 Once the napari window opens, go to **Plugins**.
-- If **Annotator (napari-napari_allencell_annotator)** is listed click it to launch. 
+- If **napari-allencell-annotator** is listed click it to launch. 
 - If it is not listed 
-- **Install/Uninstall Plugins** ⇨ check the box next to **napari-allencell-annotator** ⇨ **close** ⇨ **Plugins** ⇨ **Annotator (napari-napari_allencell_annotator)** .
+- **Install/Uninstall Plugins** ⇨ check the box next to **napari-allencell-annotator** ⇨ **close** ⇨ **Plugins** ⇨ **napari-allencell-annotator** .
 
 ### 4. Re-opening the Plugin After Installing
 - Windows
@@ -93,13 +93,13 @@ Once the napari window opens, go to **Plugins**.
   - Click on the annotator environment and wait for it to load
   - Press the play button
   - Type _napari_ in the prompt that opens
-  - Click **Plugins** ⇨ **Annotator (napari-napari_allencell_annotator)**
+  - Click **Plugins** ⇨ **napari-allencell-annotator**
 - MacOS
   - Open terminal
   - Run these commands one line at a time
     - conda activate napari_annotator
     - napari
-  - Click **Plugins** ⇨ **Annotator (napari-napari_allencell_annotator)**
+  - Click **Plugins** ⇨ **napari-allencell-annotator**
 
 ## Installation from Napari Hub
 If you have previously installed Napari on your machine, you can follow these steps to install the plugin from Napari Hub.
@@ -112,7 +112,7 @@ If you have previously installed Napari on your machine, you can follow these st
 - Close the window after the installation finishes
 
 ### 2. Launch the Plugin
-- Click **Plugins** ⇨ **Annotator (napari-napari_allencell_annotator)**
+- Click **Plugins** ⇨ **napari-allencell-annotator**
   - You might have to restart Napari for the annotator to appear in the plugin list.
   - If you still can't see the plugin, go to **Install/Uninstall Plugins** ⇨ check the box next to **napari-allencell-annotator**.
 
@@ -120,7 +120,7 @@ If you have previously installed Napari on your machine, you can follow these st
 
 1. Open napari
 2. Start the plugin 
-   - Open napari, go to **Plugins** ⇨ **Annotator (napari-napari_allencell_annotator)**.
+   - Open napari, go to **Plugins** ⇨ **napari-allencell-annotator**.
 3. Create or import annotations and add images to annotate.
 
 For more detailed usage instructions, check out this [document](napari_allencell_annotator/assets/AnnotatorInstructions.pdf) 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ If you have previously installed Napari on your machine, you can follow these st
 
 1. Open napari
 2. Start the plugin 
-   - Open napari, go to "Plugins" ⇨ "napari-allencell-annotator".
+   - Open napari, go to **Plugins** ⇨ **Annotator (napari-napari_allencell_annotator)**.
 3. Create or import annotations and add images to annotate.
 
 For more detailed usage instructions, check out this [document](napari_allencell_annotator/assets/AnnotatorInstructions.pdf) 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ image sets using these templates, and save image annotations to a csv file.
 The Allen Cell Image Annotator is a Python-based open source toolkit 
 developed at the Allen Institute for Cell Science for both blind, unbiased and un-blind 
 microscope image annotating. This toolkit supports easy image set selection
-from a file finder and creation of annotation templates (text, checkbox, drop-down, and spinbox).
+from a file finder and creation of annotation templates (text, checkbox, drop-down, spinbox, and point).
 With napari's multi-dimensional image viewing capabilities, the plugin seamlessly allows users to
 view each image and write annotations into the custom template.
 Annotation templates can be written to a json file for sharing or re-using. After annotating,
@@ -28,7 +28,8 @@ are conveniently saved to csv file, which can be re-opened for further annotatin
     - `TIFF`
     - `CZI` 
     - `PNG` 
-    -   `JPEG` 
+    - `JPEG`
+    - `OME-ZARR`
 
 
 ----------------------------------
@@ -43,7 +44,7 @@ and review the napari docs for plugin developers:
 https://napari.org/plugins/index.html
 -->
 
-## Installation
+## Installation using Command Line
 ### 1. Prerequisites
 
 The plugin requires [Conda](https://docs.anaconda.com/anaconda/install/).
@@ -100,6 +101,9 @@ Once the napari window opens, go to **Plugins**.
     - napari
   - Click **Plugins** ⇨ **napari-allencell-annotator: Annotator**
 
+## Installation using Command Line
+1. Open napari
+2. 
 ## Quick Start
 
 1. Open napari

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,4 +57,4 @@ styles =
 
 [options.entry_points]
 napari.plugin = 
-	napari-napari_allencell_annotator = napari_allencell_annotator
+	napari-allencell-annotator = napari_allencell_annotator


### PR DESCRIPTION
<h2>Changes</h2>

1. I added a section on installing the plugin from Napari Hub.
2. I updated the links to the installation scripts to point to the updated ones with python 3.10. Same as before, I uploaded the scripts to One Drive and set the access for only Allen Institute people to view. 
3. I added point annotation and ome.zarr to the template and supported extensions sections.
4. I changed the plugin option name to **Annotator (napari-napari_allencell_annotator)** to reflect the actual name in Napari.
5. I updated the python version in the conda command to 3.10.